### PR TITLE
.github: add pull request and issue templates #90

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,29 @@
+---
+name: 'Bug Report'
+about: 'Report unexpected behavior to help us improve.'
+labels: 'bug'
+---
+
+**Describe the problem**
+
+<!-- Please describe the issue you observed, and any steps we can take to reproduce it: -->
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**To Reproduce**
+
+<!-- What did you do? Describe in your own words. -->
+
+<!-- If possible, provide steps to reproduce the behavior: -->
+
+1.
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Environment:**
+
+- Kubernetes version [e.g. v1.19.5]
+- Helm version [e.g. v3.4.2]
+- RadonDB MySQL version [e.g. https://github.com/radondb/radondb-mysql-kubernetes/commit/56896cd119d9a6017e7f15f1dc0b37b83a720278]

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,21 @@
+---
+name: 'Feature Request'
+about: 'Request a new feature on the product.'
+labels: 'enhancement'
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,19 @@
+---
+name: 'Ask a Question'
+about: 'Need support & not sure if this a bug? You can ask a question.'
+labels: 'question'
+---
+
+## General Question
+
+<!--
+Before asking a question, make sure you have:
+
+- Searched existing Stack Overflow questions.
+- Googled your question.
+- Searched open and closed [GitHub issues](https://github.com/radondb/radondb-mysql-kubernetes/issues?q=is%3Aissue)
+- Read the documentation:
+  - [RadonDB MySQL Readme](https://github.com/radondb/radondb-mysql-kubernetes)
+  - [RadonDB MySQL Doc](https://github.com/radondb/radondb-mysql-kubernetes/tree/main/docs)
+  - [RadonDB MySQL Forum](https://kubesphere.com.cn/forum/t/RadonDB)
+-->

--- a/.github/ISSUE_TEMPLATE/support-request.yml
+++ b/.github/ISSUE_TEMPLATE/support-request.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Support Request
+    url: https://kubesphere.com.cn/forum/t/RadonDB
+    about: Support request or question relating to RadonDB MySQL.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- Thanks for sending a pull request!
+
+PR Title Format:
+1. pkg [, pkg2, pkg3]: what's changed #xxx
+2. *: what's changed #xxx
+
+-->
+
+### What type of PR is this?
+
+<!--
+Add one of the following types:
+/bug
+/documentation
+/cleanup
+/enhancement
+-->
+
+### Which issue(s) this PR fixes?
+
+<!--
+Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #
+
+### What this PR does?
+
+Summary:
+
+### Special notes for your reviewer?


### PR DESCRIPTION

### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #90 

### What this PR does?

Summary:

Refer to [the github article](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), add pull request and issue templates for radondb-mysql-kubernetes.

We can customize and standardize the information we'd like contributors to include when they open issues and pull requests in radondb-mysql-kubernetes.

### Special notes for your reviewer?

N/A