### PR TITLE
add deploy links on README.md and README_zh.md #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ At present, RadonDB MySQL has supported the deployment of MySQL high availabilit
 ## Installation
 
 - [Deploy RadonDB MySQL on Kubernetes](docs/Kubernetes/deploy_radondb-mysql_on_kubernetes.md)
-- [Deploy RadonDB MySQL on the appstore of KubeSphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere.md)
-
+- [Deploy RadonDB MySQL through git on Kubesphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere.md)
+- [Deploy RadonDB MySQL through helm repo on Kubesphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere_repo.md)
+- [Deploy RadonDB MySQL through Appstore of KubeSphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere_appstore.md)
 ## Release
 
 | Release | Features  | Mode |

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,7 +32,9 @@
 ## 快速部署
 
 - [ 在 Kubernetes 上部署 RadonDB MySQL 集群](docs/Kubernetes/deploy_radondb-mysql_on_kubernetes.md)
-- [ 在 Kubesphere 上部署 RadonDB MySQL 集群 ](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere.md)
+- [在 KubeSphere 上通过 Git 部署 RadonDB MySQL 集群](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere.md)
+- [在 KubeSphere 上通过 Helm Repo 部署 RadonDB MySQL 集群](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere_repo.md)
+- [在 KubeSphere 上通过应用商店部署 RadonDB MySQL 集群](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere_appstore.md)
 
 ## 版本路线
 


### PR DESCRIPTION
add links 

- [Deploy RadonDB MySQL through git on Kubesphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere.md)
- [Deploy RadonDB MySQL through helm repo on Kubesphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere_repo.md)
- [Deploy RadonDB MySQL through Appstore of KubeSphere](docs/KubeSphere/deploy_radondb-mysql_on_kubesphere_appstore.md)