### PR TITLE
syncer: support external network access service and automatic expose metrics port #156 

### DIFF
--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -14,7 +14,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 manager:
-  image: zhyass/manager
+  image: radondb/mysql-operator
   tag: 0.1
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/cluster/syncer/follower_service.go
+++ b/cluster/syncer/follower_service.go
@@ -41,18 +41,32 @@ func NewFollowerSVCSyncer(cli client.Client, c *cluster.Cluster) syncer.Interfac
 		},
 	}
 	return syncer.NewObjectSyncer("FollowerSVC", c.Unwrap(), service, cli, func() error {
-		service.Spec.Type = "ClusterIP"
+		if service.Spec.Type == "" {
+			service.Spec.Type = "ClusterIP"
+		}	
+			
 		service.Spec.Selector = c.GetSelectorLabels()
 		service.Spec.Selector["role"] = "follower"
 		service.Spec.Selector["healthy"] = "yes"
 
-		if len(service.Spec.Ports) != 1 {
-			service.Spec.Ports = make([]corev1.ServicePort, 1)
+		svcPorts := []corev1.ServicePort{
+			{
+				Name:       utils.MysqlPortName,
+				Port:       utils.MysqlPort,
+				TargetPort: intstr.FromInt(utils.MysqlPort),
+			},
 		}
 
-		service.Spec.Ports[0].Name = utils.MysqlPortName
-		service.Spec.Ports[0].Port = utils.MysqlPort
-		service.Spec.Ports[0].TargetPort = intstr.FromInt(utils.MysqlPort)
+		if c.Spec.MetricsOpts.Enabled {
+			svcPorts = append(svcPorts, corev1.ServicePort{
+				Name:       utils.MetricsPortName,
+				Port:       utils.MetricsPort,
+				TargetPort: intstr.FromInt(utils.MetricsPort),
+			})
+		}
+
+		service.Spec.Ports = svcPorts
+		
 		return nil
 	})
 }

--- a/config/samples/mysql_v1alpha1_cluster.yaml
+++ b/config/samples/mysql_v1alpha1_cluster.yaml
@@ -55,7 +55,7 @@ spec:
 
   podSpec:
     imagePullPolicy: IfNotPresent
-    sidecarImage: zhyass/sidecar:0.1
+    sidecarImage: radondb/mysql-sidecar:0.1
     busyboxImage: busybox:1.32
 
     slowLogTail: false


### PR DESCRIPTION

### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

this pr is for metrics feature, custom monitoring panel in k8e needs to expose the ports of the metrics container,
and users may need to use other monitoring panels outside of k8e.

Fixes #156

### What this PR does?

Summary:

1. The external network access mode is fixed to ClusterIP, and editing is not allowed -> Editing is allowed, the default is ClusterIP
2. Editing the service port is not allowed, the mysql port is exposed by default -> If metrics is enabled, metrics port will be automatically exposed
3. move manager and sidecar images to radondb(Already repackaged)

### Special notes for your reviewer?

Test whether it meets expectations through installation