### PR TITLE
*: add serviceMonitor for operator #169

### DIFF
--- a/charts/mysql-operator/templates/_helpers.tpl
+++ b/charts/mysql-operator/templates/_helpers.tpl
@@ -40,3 +40,16 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "mysql-operator.labels" -}}
+app.kubernetes.io/name: {{ include "mysql-operator.name" . }}
+helm.sh/chart: {{ include "mysql-operator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/mysql-operator/templates/servicemonitor.yaml
+++ b/charts/mysql-operator/templates/servicemonitor.yaml
@@ -1,0 +1,28 @@
+{{ if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" -}}{{ if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "mysql-operator.fullname" . }}
+  labels:
+    {{- include "mysql-operator.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.additionalLabels }}
+    {{- end }}
+spec:
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels: {{ .Values.serviceMonitor.targetLabels }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.podTargetLabels }}
+  podTargetLabels: {{ .Values.serivceMonitor.podTargetLabels }}
+  {{- end }}
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      port: metrics
+      path: /metrics
+  namespaceSelector: {{ toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
+  selector: {{ toYaml .Values.serviceMonitor.selector | nindent 4 }}
+{{ end -}}{{ end -}}

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -43,3 +43,21 @@ rbacProxy:
 
 leaderElection:
   create: true
+
+serviceMonitor:
+  enabled: true
+  ## Additional labels for the serviceMonitor. Useful if you have multiple prometheus operators running to select only specific ServiceMonitors
+  # additionalLabels:
+  #   prometheus: prom-internal
+  interval: 10s
+  scrapeTimeout: 3s
+  # jobLabel:
+  # targetLabels:
+  # podTargetLabels:
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: mysql.radondb.com
+      app.kubernetes.io/name: mysql
+

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -260,6 +260,8 @@ func (c *Cluster) GetNameForResource(name utils.ResourceName) string {
 		return fmt.Sprintf("%s-leader", c.Name)
 	case utils.FollowerService:
 		return fmt.Sprintf("%s-follower", c.Name)
+	case utils.MetricsService:
+		return fmt.Sprintf("%s-metrics", c.Name)
 	case utils.Secret:
 		return fmt.Sprintf("%s-secret", c.Name)
 	default:

--- a/cluster/syncer/metrics_service.go
+++ b/cluster/syncer/metrics_service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/presslabs/controller-util/syncer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,42 +27,31 @@ import (
 	"github.com/radondb/radondb-mysql-kubernetes/utils"
 )
 
-// NewHeadlessSVCSyncer returns headless service syncer.
-func NewHeadlessSVCSyncer(cli client.Client, c *cluster.Cluster) syncer.Interface {
+// NewMetricsSVCSyncer returns metrics service syncer.
+func NewMetricsSVCSyncer(cli client.Client, c *cluster.Cluster) syncer.Interface {
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.GetNameForResource(utils.HeadlessSVC),
+			Name:      c.GetNameForResource(utils.MetricsService),
 			Namespace: c.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       "mysql",
-				"app.kubernetes.io/managed-by": "mysql.radondb.com",
-			},
+			Labels:    c.GetLabels(),
 		},
 	}
-
-	return syncer.NewObjectSyncer("HeadlessSVC", c.Unwrap(), service, cli, func() error {
+	return syncer.NewObjectSyncer("MetricsSVC", c.Unwrap(), service, cli, func() error {
 		service.Spec.Type = "ClusterIP"
-		service.Spec.ClusterIP = "None"
-		service.Spec.Selector = labels.Set{
-			"app.kubernetes.io/name":       "mysql",
-			"app.kubernetes.io/managed-by": "mysql.radondb.com",
-		}
-
-		// Use `publishNotReadyAddresses` to be able to access pods even if the pod is not ready.
-		service.Spec.PublishNotReadyAddresses = true
+		service.Spec.Selector = c.GetSelectorLabels()
 
 		if len(service.Spec.Ports) != 1 {
 			service.Spec.Ports = make([]corev1.ServicePort, 1)
 		}
 
-		service.Spec.Ports[0].Name = utils.MysqlPortName
-		service.Spec.Ports[0].Port = utils.MysqlPort
-		service.Spec.Ports[0].TargetPort = intstr.FromInt(utils.MysqlPort)
-
+		service.Spec.Ports[0].Name = utils.MetricsPortName
+		service.Spec.Ports[0].Port = utils.MetricsPort
+		service.Spec.Ports[0].TargetPort = intstr.FromInt(utils.MetricsPort)
+		
 		return nil
 	})
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -118,6 +118,10 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		clustersyncer.NewPDBSyncer(r.Client, instance),
 	}
 
+	if instance.Spec.MetricsOpts.Enabled {
+		syncers = append(syncers, clustersyncer.NewMetricsSVCSyncer(r.Client, instance))
+	}
+
 	// run the syncers
 	for _, sync := range syncers {
 		if err = syncer.Sync(ctx, sync, r.Recorder); err != nil {

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -105,6 +105,8 @@ const (
 	LeaderService ResourceName = "leader-service"
 	// FollowerService is the name of a service that points healthy followers (excludes leader).
 	FollowerService ResourceName = "follower-service"
+	//MetricsService is the name of the metrics service that points to all nodes.
+	MetricsService ResourceName = "metrics-service"
 	// Secret is the name of the secret that contains operator related credentials.
 	Secret ResourceName = "secret"
 	// Role is the alias of the role resource.


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #169

### What this PR does?

Summary: 

- install servicemonitor when install operator.
- create metrics service when metrics enable

### Special notes for your reviewer?

For testing, please set the manager image in `charts/mysql-operator/values.yaml` to `runkecheng/mysql-operator` and set `config/samples/mysql_v1alpha1_cluster.yaml` : 
```
metricsOpts:
    enabled: true
``` 

If you are using qke, you can configure port forwarding for the `prometheus-k8s` service which under `kubesphere-monitoring-system` ns, and then you can access prometheus through the external network and view related data interfaces.