### PR TITLE
use ipv4

### DIFF
--- a/charts/helm/dockerfiles/xenon/xenon-entry.sh
+++ b/charts/helm/dockerfiles/xenon/xenon-entry.sh
@@ -58,7 +58,7 @@ build_conf() {
 		"admin": "root",
 		"ping-timeout": 2000,
 		"passwd": "%s",
-		"host": "localhost",
+		"host": "127.0.0.1",
 		"version": "mysql57",
 		"master-sysvars": "%s",
 		"slave-sysvars": "%s",


### PR DESCRIPTION
### What this PR does?

Summary:

When localhost resolved ipv6 address(`::1`)，root access will be denied(root access only allow `localhost` and `127.0.0.1` by default).

So use ipv4 access explicitly is better.
