### PR TITLE
sidecar: rm uneffective version of mysql56 #203

### DIFF
--- a/sidecar/config.go
+++ b/sidecar/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sidecar
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -172,7 +173,9 @@ func (cfg *Config) buildXenonConf() []byte {
 	version := "mysql80"
 	if cfg.MySQLVersion.Major == 5 {
 		// currently we do not support mysql 5.6 or lower version.
-		log.Info("currently we do not support mysql 5.6 or lower version, default we set mysql 5.7")
+		if cfg.MySQLVersion.Minor != 7 {
+			log.Error(errors.New("uneffective mysql version."), "currently we do not support mysql 5.6 or lower version, default we set mysql 5.7")
+		}
 		version = "mysql57"
 	}
 

--- a/sidecar/config.go
+++ b/sidecar/config.go
@@ -72,7 +72,7 @@ type Config struct {
 
 	// The parameter in xenon means admit defeat count for hearbeat.
 	AdmitDefeatHearbeatCount int32
-	// The parameter in xenon means election timeout(ms)。
+	// The parameter in xenon means election timeout(ms).
 	ElectionTimeout int32
 
 	// Whether the MySQL data exists.
@@ -171,11 +171,9 @@ func (cfg *Config) buildXenonConf() []byte {
 
 	version := "mysql80"
 	if cfg.MySQLVersion.Major == 5 {
-		if cfg.MySQLVersion.Minor == 6 {
-			version = "mysql56"
-		} else {
-			version = "mysql57"
-		}
+		// currently we do not support mysql 5.6 or lower version.
+		log.Info("currently we do not support mysql 5.6 or lower version, default we set mysql 5.7")
+		version = "mysql57"
 	}
 
 	var masterSysVars, slaveSysVars string


### PR DESCRIPTION
[summary]
rm uneffective version of mysql56, currently we do not support mysql 5.6
or lower version

[test case]
N/A

[patch codecov]
N/A

<!-- Thanks for sending a pull request!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed #xxx
2. *: what's changed #xxx

-->

### What type of PR is this?

<!--
Add one of the following types:
/bug
/documentation
/cleanup
/enhancement
-->

### Which issue(s) this PR fixes?

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #203

### What this PR does?

Summary:
rm uneffective version of mysql56, currently we do not support mysql 5.6
or lower version


### Special notes for your reviewer?
