### PR TITLE
*: Make the cluster state cover more scenarios. #253

### DIFF
--- a/api/v1alpha1/mysqlcluster_types.go
+++ b/api/v1alpha1/mysqlcluster_types.go
@@ -242,16 +242,34 @@ type Persistence struct {
 	Size string `json:"size,omitempty"`
 }
 
+// ClusterState defines cluster state.
+type ClusterState string
+
+const (
+	// ClusterInitState  indicates whether the cluster is initializing.
+	ClusterInitState  ClusterState = "Initializing"
+	// ClusterUpdateState indicates whether the cluster is being updated.
+	ClusterUpdateState ClusterState = "Updating"
+	// ClusterReadyState indicates whether all containers in the pod are ready.
+	ClusterReadyState ClusterState = "Ready"
+	// ClusterCloseState indicates whether the cluster is closed.
+	ClusterCloseState ClusterState = "Closed"
+)
+
 // ClusterConditionType defines type for cluster condition type.
 type ClusterConditionType string
 
 const (
-	// ClusterInit indicates whether the cluster is initializing.
-	ClusterInit ClusterConditionType = "Initializing"
-	// ClusterReady indicates whether all containers in the pod are ready.
-	ClusterReady ClusterConditionType = "Ready"
-	// ClusterError indicates whether the cluster encountered an error.
-	ClusterError ClusterConditionType = "Error"
+	// ConditionInit indicates whether the cluster is initializing.
+	ConditionInit ClusterConditionType = "Initializing"
+	// ConditionUpdate indicates whether the cluster is being updated.
+	ConditionUpdate ClusterConditionType = "Updating"
+	// ConditionReady indicates whether all containers in the pod are ready.
+	ConditionReady ClusterConditionType = "Ready"
+	// ConditionClose indicates whether the cluster is closed.
+	ConditionClose ClusterConditionType = "Closed"
+	// ConditionError indicates whether there is an error in the cluster.
+	ConditionError ClusterConditionType = "Error"
 )
 
 // ClusterCondition defines type for cluster conditions.
@@ -321,7 +339,7 @@ type MysqlClusterStatus struct {
 	// ReadyNodes represents number of the nodes that are in ready state.
 	ReadyNodes int `json:"readyNodes,omitempty"`
 	// State
-	State ClusterConditionType `json:"state,omitempty"`
+	State ClusterState `json:"state,omitempty"`
 	// Conditions contains the list of the cluster conditions fulfilled.
 	Conditions []ClusterCondition `json:"conditions,omitempty"`
 	// Nodes contains the list of the node status fulfilled.

--- a/mysqlcluster/syncer/statefulset.go
+++ b/mysqlcluster/syncer/statefulset.go
@@ -470,6 +470,7 @@ func (s *StatefulSetSyncer) applyNWait(ctx context.Context, pod *corev1.Pod) err
 	if pod.ObjectMeta.Labels["controller-revision-hash"] == s.sfs.Status.UpdateRevision {
 		log.Info("pod is already updated", "pod name", pod.Name)
 	} else {
+		s.Status.State = apiv1alpha1.ClusterUpdateState
 		log.Info("updating pod", "pod", pod.Name, "key", s.Unwrap())
 		if pod.DeletionTimestamp != nil {
 			log.Info("pod is being deleted", "pod", pod.Name, "key", s.Unwrap())


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #253 

### What this PR does?

Summary: 

- Added `ClusterState` type, used to distinguish `condition.type` and `status.state`.
- Fix that the cluster status will be set to error when each pod is initialized.
- Added a status type `updating`, it's includes adding and deleting nodes and updating the configuration.
- Added a status type `closed`, represents the case where the replicas is 0.

### Special notes for your reviewer?

operator image for testing: radondb/mysql-operator:test1013
