### PR TITLE
Makefile: Synchronize the generated files to Chart while generating CRD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+update-crd:	## Synchronize the generated YAML files to operator Chart after make manifests.
+	make manifests
+	cp config/crd/bases/* charts/mysql-operator/crds/
+
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #279 

### What this PR does?

Summary:

Added a new `update-crd` method in Makefile，It is used to synchronize the generated YAML files to operator Chart after make manifests.

### Special notes for your reviewer?
