### PR TITLE
status: Nodes.Conitions only contains the conition of the node present in the cluster. #283

### DIFF
--- a/mysqlcluster/syncer/status.go
+++ b/mysqlcluster/syncer/status.go
@@ -254,6 +254,10 @@ func (s *StatusSyncer) updateNodeStatus(ctx context.Context, cli client.Client, 
 		}
 	}
 
+	// Delete node status of nodes that have been deleted.
+	if len(s.Status.Nodes) > len(pods) {
+		s.Status.Nodes = s.Status.Nodes[:len(pods)]
+	}
 	return nil
 }
 


### PR DESCRIPTION
### What type of PR is this?

/bug

### Which issue(s) this PR fixes?

Fixes #283 

### What this PR does?

Summary:

Let Nodes.Conitions only contains the conition of the node present in the cluster.

### Special notes for your reviewer?
