### PR TITLE
syncer: Optimize update POD trigger conditions

### DIFF
--- a/mysqlcluster/syncer/statefulset.go
+++ b/mysqlcluster/syncer/statefulset.go
@@ -289,7 +289,7 @@ func (s *StatefulSetSyncer) createOrUpdate(ctx context.Context) (controllerutil.
 // updatePod update the pods, update follower nodes first.
 // This can reduce the number of master-slave switching during the update process.
 func (s *StatefulSetSyncer) updatePod(ctx context.Context) error {
-	if s.sfs.Status.UpdatedReplicas >= s.sfs.Status.Replicas {
+	if s.sfs.Status.UpdateRevision == s.sfs.Status.CurrentRevision {
 		return nil
 	}
 


### PR DESCRIPTION
### What type of PR is this?

/bug

### Which issue(s) this PR fixes?

Fixes #320 

### What this PR does?

If only `replicas` changes, StatefulSet does not generate new `Revison` , so the `UpdatedReplicas` has always been 0.

```
status:
  collisionCount: 0
  currentRevision: sample-mysql-55677794
  observedGeneration: 6
  replicas: 0
  updateRevision: sample-mysql-55677794
```

Summary: Use the revision to determine if the POD needs to be updated.

### Special notes for your reviewer?
