### PR TITLE
*: Support more role labels.

### DIFF
--- a/mysqlcluster/syncer/follower_service.go
+++ b/mysqlcluster/syncer/follower_service.go
@@ -48,7 +48,7 @@ func NewFollowerSVCSyncer(cli client.Client, c *mysqlcluster.MysqlCluster) synce
 			service.Spec.Type = "ClusterIP"
 		}
 		service.Spec.Selector = c.GetSelectorLabels()
-		service.Spec.Selector["role"] = "follower"
+		service.Spec.Selector["role"] = string(utils.Follower)
 		service.Spec.Selector["healthy"] = "yes"
 
 		if len(service.Spec.Ports) != 2 {

--- a/mysqlcluster/syncer/leader_service.go
+++ b/mysqlcluster/syncer/leader_service.go
@@ -48,7 +48,7 @@ func NewLeaderSVCSyncer(cli client.Client, c *mysqlcluster.MysqlCluster) syncer.
 			service.Spec.Type = "ClusterIP"
 		}
 		service.Spec.Selector = c.GetSelectorLabels()
-		service.Spec.Selector["role"] = "leader"
+		service.Spec.Selector["role"] = string(utils.Leader)
 
 		if len(service.Spec.Ports) != 2 {
 			service.Spec.Ports = make([]corev1.ServicePort, 2)

--- a/mysqlcluster/syncer/statefulset.go
+++ b/mysqlcluster/syncer/statefulset.go
@@ -332,9 +332,12 @@ func (s *StatefulSetSyncer) updatePod(ctx context.Context) error {
 			return err
 		}
 	}
-	// Update the leader.
-	if err := s.applyNWait(ctx, &leaderPod); err != nil {
-		return err
+	// There may be a case where Leader does not exist during the update process.
+	if leaderPod.Name != "" {
+		// Update the leader.
+		if err := s.applyNWait(ctx, &leaderPod); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/sidecar/config.go
+++ b/sidecar/config.go
@@ -345,8 +345,6 @@ func (cfg *Config) buildXenonConf() []byte {
 			"admit-defeat-hearbeat-count": %d,
 			"heartbeat-timeout": %d,
 			"meta-datadir": "/var/lib/xenon/",
-			"leader-start-command": "/scripts/leader-start.sh",
-			"leader-stop-command": "/scripts/leader-stop.sh",
 			"semi-sync-degrade": true,
 			"purge-binlog-disabled": true,
 			"super-idle": false
@@ -408,25 +406,25 @@ func (cfg *Config) buildClientConfig() (*ini.File, error) {
 	return conf, nil
 }
 
-// buildLeaderStart build the leader-start.sh.
-func (cfg *Config) buildLeaderStart() []byte {
-	str := fmt.Sprintf(`#!/usr/bin/env bash
-curl -X PATCH -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type: application/json-patch+json" \
---cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/%s/pods/$HOSTNAME \
--d '[{"op": "replace", "path": "/metadata/labels/role", "value": "leader"}]'
-`, cfg.NameSpace)
-	return utils.StringToBytes(str)
-}
+// // buildLeaderStart build the leader-start.sh.
+// func (cfg *Config) buildLeaderStart() []byte {
+// 	str := fmt.Sprintf(`#!/usr/bin/env bash
+// curl -X PATCH -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type: application/json-patch+json" \
+// --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/%s/pods/$HOSTNAME \
+// -d '[{"op": "replace", "path": "/metadata/labels/role", "value": "leader"}]'
+// `, cfg.NameSpace)
+// 	return utils.StringToBytes(str)
+// }
 
-// buildLeaderStop build the leader-stop.sh.
-func (cfg *Config) buildLeaderStop() []byte {
-	str := fmt.Sprintf(`#!/usr/bin/env bash
-curl -X PATCH -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type: application/json-patch+json" \
---cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/%s/pods/$HOSTNAME \
--d '[{"op": "replace", "path": "/metadata/labels/role", "value": "follower"}]'
-`, cfg.NameSpace)
-	return utils.StringToBytes(str)
-}
+// // buildLeaderStop build the leader-stop.sh.
+// func (cfg *Config) buildLeaderStop() []byte {
+// 	str := fmt.Sprintf(`#!/usr/bin/env bash
+// curl -X PATCH -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type: application/json-patch+json" \
+// --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/api/v1/namespaces/%s/pods/$HOSTNAME \
+// -d '[{"op": "replace", "path": "/metadata/labels/role", "value": "follower"}]'
+// `, cfg.NameSpace)
+// 	return utils.StringToBytes(str)
+// }
 
 /* The function is equivalent to the following shell script template:
 #!/bin/sh

--- a/sidecar/init.go
+++ b/sidecar/init.go
@@ -177,19 +177,19 @@ func runInitCommand(cfg *Config) error {
 		return fmt.Errorf("failed to save extra.cnf: %s", err)
 	}
 
-	// build leader-start.sh.
-	bashLeaderStart := cfg.buildLeaderStart()
-	leaderStartPath := path.Join(scriptsPath, "leader-start.sh")
-	if err = ioutil.WriteFile(leaderStartPath, bashLeaderStart, os.FileMode(0755)); err != nil {
-		return fmt.Errorf("failed to write leader-start.sh: %s", err)
-	}
+	// // build leader-start.sh.
+	// bashLeaderStart := cfg.buildLeaderStart()
+	// leaderStartPath := path.Join(scriptsPath, "leader-start.sh")
+	// if err = ioutil.WriteFile(leaderStartPath, bashLeaderStart, os.FileMode(0755)); err != nil {
+	// 	return fmt.Errorf("failed to write leader-start.sh: %s", err)
+	// }
 
-	// build leader-stop.sh.
-	bashLeaderStop := cfg.buildLeaderStop()
-	leaderStopPath := path.Join(scriptsPath, "leader-stop.sh")
-	if err = ioutil.WriteFile(leaderStopPath, bashLeaderStop, os.FileMode(0755)); err != nil {
-		return fmt.Errorf("failed to write leader-stop.sh: %s", err)
-	}
+	// // build leader-stop.sh.
+	// bashLeaderStop := cfg.buildLeaderStop()
+	// leaderStopPath := path.Join(scriptsPath, "leader-stop.sh")
+	// if err = ioutil.WriteFile(leaderStopPath, bashLeaderStop, os.FileMode(0755)); err != nil {
+	// 	return fmt.Errorf("failed to write leader-stop.sh: %s", err)
+	// }
 
 	// for install tokudb.
 	if cfg.InitTokuDB {

--- a/sidecar/util.go
+++ b/sidecar/util.go
@@ -46,8 +46,8 @@ var (
 	// dataPath is the mysql data path.
 	dataPath = utils.DataVolumeMountPath
 
-	// scriptsPath is the scripts path used for xenon.
-	scriptsPath = utils.ScriptsVolumeMountPath
+	// // scriptsPath is the scripts path used for xenon.
+	// scriptsPath = utils.ScriptsVolumeMountPath
 
 	// sysPath is the linux kernel path used for install tokudb.
 	sysPath = utils.SysVolumeMountPath


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #330 

### What this PR does?

execute `xenoncli raft disable` in leader `sample-mysql-2`. then `sample-mysql-2` become `IDLE`, Cluster re-electing.

```
xenoncli cluster status
+------------------------------------------+-------------------------------+--------+---------+--------------------------+---------------------+----------------+------------------------------------------+
|                    ID                    |             Raft              | Mysqld | Monitor |          Backup          |        Mysql        | IO/SQL_RUNNING |                 MyLeader                 |
+------------------------------------------+-------------------------------+--------+---------+--------------------------+---------------------+----------------+------------------------------------------+
| sample-mysql-2.sample-mysql.default:8801 | [ViewID:4 EpochID:2]@IDLE     | UNKNOW | OFF     | state:[NONE]␤            | [ALIVE] [READONLY]  | [true/true]    | sample-mysql-0.sample-mysql.default:8801 |
|                                          |                               |        |         | LastError:               |                     |                |                                          |
+------------------------------------------+-------------------------------+--------+---------+--------------------------+---------------------+----------------+------------------------------------------+
| sample-mysql-0.sample-mysql.default:8801 | [ViewID:4 EpochID:2]@LEADER   | UNKNOW | OFF     | state:[NONE]␤            | [ALIVE] [READWRITE] | [true/true]    | sample-mysql-0.sample-mysql.default:8801 |
|                                          |                               |        |         | LastError:               |                     |                |                                          |
+------------------------------------------+-------------------------------+--------+---------+--------------------------+---------------------+----------------+------------------------------------------+
| sample-mysql-1.sample-mysql.default:8801 | [ViewID:4 EpochID:2]@FOLLOWER | UNKNOW | OFF     | state:[NONE]␤            | [ALIVE] [READONLY]  | [true/true]    | sample-mysql-0.sample-mysql.default:8801 |
|                                          |                               |        |         | LastError:               |                     |                |                                          |
+------------------------------------------+-------------------------------+--------+---------+--------------------------+---------------------+----------------+------------------------------------------+
```

You can see that the role tag has been set to a corresponding role.

```
# all pods
kubectl get pod -o wide | grep sample
sample-mysql-0                         3/3     Running   0          40m     10.233.96.114   node2    <none>           <none>
sample-mysql-1                         3/3     Running   0          39m     10.233.90.108   node1    <none>           <none>
sample-mysql-2                         3/3     Running   0          37m     10.233.70.59    master   <none>           <none>
# leader
kubectl get -l role=LEADER pod
NAME             READY   STATUS    RESTARTS   AGE
sample-mysql-0   3/3     Running   0          30m
# follower
kubectl get -l role=FOLLOWER pod
NAME             READY   STATUS    RESTARTS   AGE
sample-mysql-1   3/3     Running   0          29m
# idle (disable raft)
kubectl get -l role=IDLE pod
NAME             READY   STATUS    RESTARTS   AGE
sample-mysql-2   3/3     Running   0          28m
```

```
kubectl describe svc sample-mysql
Name:              sample-mysql
...
Port:              mysql  3306/TCP
TargetPort:        3306/TCP
Endpoints:         10.233.70.59:3306,10.233.90.108:3306,10.233.96.114:3306
...

kubectl describe svc sample-follower
Name:              sample-follower
...
Port:              mysql  3306/TCP
TargetPort:        3306/TCP
Endpoints:         10.233.90.108:3306
...

kubectl describe svc sample-leader
Name:              sample-leader
...
Port:              mysql  3306/TCP
TargetPort:        3306/TCP
Endpoints:         10.233.96.114:3306
...

```
### Special notes for your reviewer?
