### PR TITLE
*: Save Xenon's metadata to persistent storage. #406

### DIFF
--- a/mysqlcluster/container/backup.go
+++ b/mysqlcluster/container/backup.go
@@ -134,6 +134,7 @@ func (c *backupSidecar) getVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      utils.DataVolumeName,
 			MountPath: utils.DataVolumeMountPath,
+			SubPath:   utils.MysqlDataSubPath,
 		},
 		{
 			Name:      utils.LogsVolumeName,

--- a/mysqlcluster/container/init_mysql.go
+++ b/mysqlcluster/container/init_mysql.go
@@ -115,6 +115,7 @@ func (c *initMysql) getVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      utils.DataVolumeName,
 			MountPath: utils.DataVolumeMountPath,
+			SubPath:   utils.MysqlDataSubPath,
 		},
 		{
 			Name:      utils.LogsVolumeName,

--- a/mysqlcluster/container/init_mysql_test.go
+++ b/mysqlcluster/container/init_mysql_test.go
@@ -59,6 +59,7 @@ var (
 		{
 			Name:      utils.DataVolumeName,
 			MountPath: utils.DataVolumeMountPath,
+			SubPath:   utils.MysqlDataSubPath,
 		},
 		{
 			Name:      utils.LogsVolumeName,

--- a/mysqlcluster/container/init_sidecar.go
+++ b/mysqlcluster/container/init_sidecar.go
@@ -202,6 +202,12 @@ func (c *initSidecar) getVolumeMounts() []corev1.VolumeMount {
 			corev1.VolumeMount{
 				Name:      utils.DataVolumeName,
 				MountPath: utils.DataVolumeMountPath,
+				SubPath:   utils.MysqlDataSubPath,
+			},
+			corev1.VolumeMount{
+				Name:      utils.DataVolumeName,
+				MountPath: utils.XenonDataVolumeMountPath,
+				SubPath:   utils.XenonDataSubPath,
 			},
 		)
 	}

--- a/mysqlcluster/container/init_sidecar_test.go
+++ b/mysqlcluster/container/init_sidecar_test.go
@@ -455,10 +455,18 @@ func TestGetInitSidecarVolumeMounts(t *testing.T) {
 		persistenceCase := EnsureContainer("init-sidecar", &testPersistenceCluster)
 		persistenceVolumeMounts := make([]corev1.VolumeMount, 6, 7)
 		copy(persistenceVolumeMounts, defaultInitsidecarVolumeMounts)
-		persistenceVolumeMounts = append(persistenceVolumeMounts, corev1.VolumeMount{
-			Name:      utils.DataVolumeName,
-			MountPath: utils.DataVolumeMountPath,
-		})
+		persistenceVolumeMounts = append(persistenceVolumeMounts,
+			corev1.VolumeMount{
+				Name:      utils.DataVolumeName,
+				MountPath: utils.DataVolumeMountPath,
+				SubPath:   utils.MysqlDataSubPath,
+			},
+			corev1.VolumeMount{
+				Name:      utils.DataVolumeName,
+				MountPath: utils.XenonDataVolumeMountPath,
+				SubPath:   utils.XenonDataSubPath,
+			},
+		)
 		assert.Equal(t, persistenceVolumeMounts, persistenceCase.VolumeMounts)
 	}
 }

--- a/mysqlcluster/container/mysql.go
+++ b/mysqlcluster/container/mysql.go
@@ -141,6 +141,7 @@ func (c *mysql) getVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      utils.DataVolumeName,
 			MountPath: utils.DataVolumeMountPath,
+			SubPath:   utils.MysqlDataSubPath,
 		},
 		{
 			Name:      utils.LogsVolumeName,

--- a/mysqlcluster/container/mysql_test.go
+++ b/mysqlcluster/container/mysql_test.go
@@ -147,6 +147,7 @@ func TestGetMysqlVolumeMounts(t *testing.T) {
 		{
 			Name:      "data",
 			MountPath: "/var/lib/mysql",
+			SubPath:   "mysql",
 		},
 		{
 			Name:      "logs",

--- a/mysqlcluster/container/xenon.go
+++ b/mysqlcluster/container/xenon.go
@@ -111,6 +111,11 @@ func (c *xenon) getVolumeMounts() []corev1.VolumeMount {
 			MountPath: utils.ScriptsVolumeMountPath,
 		},
 		{
+			Name:      utils.DataVolumeName,
+			MountPath: utils.XenonDataVolumeMountPath,
+			SubPath:   utils.XenonDataSubPath,
+		},
+		{
 			Name:      utils.XenonVolumeName,
 			MountPath: utils.XenonVolumeMountPath,
 		},

--- a/mysqlcluster/container/xenon_test.go
+++ b/mysqlcluster/container/xenon_test.go
@@ -131,6 +131,11 @@ func TestGetXenonVolumeMounts(t *testing.T) {
 			MountPath: "/scripts",
 		},
 		{
+			Name:      "data",
+			MountPath: "/var/lib/xenon",
+			SubPath:   "xenon",
+		},
+		{
 			Name:      "xenon",
 			MountPath: "/etc/xenon",
 		},

--- a/sidecar/init.go
+++ b/sidecar/init.go
@@ -133,6 +133,10 @@ func runInitCommand(cfg *Config) error {
 		if err = os.Chown(dataPath, uid, gid); err != nil {
 			return fmt.Errorf("failed to chown %s: %s", dataPath, err)
 		}
+		// chown -R mysql:mysql /var/lib/xenon.
+		if err = os.Chown(xenonDataPath, uid, gid); err != nil {
+			return fmt.Errorf("failed to chown %s: %s", xenonDataPath, err)
+		}
 	}
 
 	// copy appropriate my.cnf from config-map to config mount.

--- a/sidecar/util.go
+++ b/sidecar/util.go
@@ -45,6 +45,8 @@ var (
 
 	// dataPath is the mysql data path.
 	dataPath = utils.DataVolumeMountPath
+	// xenonMetaDataPath is the xenon metadata path.
+	xenonDataPath = utils.XenonDataVolumeMountPath
 
 	// // scriptsPath is the scripts path used for xenon.
 	// scriptsPath = utils.ScriptsVolumeMountPath

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -99,14 +99,17 @@ const (
 	InitFileVolumeName = "init-mysql"
 
 	// volumes mount path.
-	ConfVolumeMountPath     = "/etc/mysql"
-	ConfMapVolumeMountPath  = "/mnt/config-map"
-	LogsVolumeMountPath     = "/var/log/mysql"
-	DataVolumeMountPath     = "/var/lib/mysql"
-	SysVolumeMountPath      = "/host-sys"
-	ScriptsVolumeMountPath  = "/scripts"
-	XenonVolumeMountPath    = "/etc/xenon"
-	InitFileVolumeMountPath = "/docker-entrypoint-initdb.d"
+	ConfVolumeMountPath      = "/etc/mysql"
+	ConfMapVolumeMountPath   = "/mnt/config-map"
+	LogsVolumeMountPath      = "/var/log/mysql"
+	DataVolumeMountPath      = "/var/lib/mysql"
+	XenonDataVolumeMountPath = "/var/lib/xenon"
+	SysVolumeMountPath       = "/host-sys"
+	ScriptsVolumeMountPath   = "/scripts"
+	XenonVolumeMountPath     = "/etc/xenon"
+	InitFileVolumeMountPath  = "/docker-entrypoint-initdb.d"
+	MysqlDataSubPath         = "mysql"
+	XenonDataSubPath         = "xenon"
 
 	// Volume timezone name.
 	SysLocalTimeZone = "localtime"


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #406

### What this PR does?

Summary:

MySQL and Xenon mount the same volume but use different subpath.

```
     containers:
        - name: mysql
           volumeMounts:
              mountPath: /var/lib/mysql
              subPath: mysql
              ...
        - name: xenon
           volumeMounts:
              mountPath: /var/lib/xenon
              subPath: xenon
```

Xenon cannot see MySQL dir.
```
 kubectl exec -it sample-mysql-0 -c xenon -- ls /var/lib/
apk     misc    udhcpd  xenon
```

MySQL cannot see Xenon dir.

```
kubectl exec -it sample-mysql-0 -c mysql -- ls /var/lib/
alternatives  dnf        misc         mysql-keyring  rpm        systemd
dbus          games      mysql        portables      rpm-state
dhclient      initramfs  mysql-files  private        selinux
```

### Special notes for your reviewer?
