### PR TITLE
status: Skip the unavailable node and set default node status. #417

### DIFF
--- a/mysqlcluster/syncer/status.go
+++ b/mysqlcluster/syncer/status.go
@@ -193,7 +193,8 @@ func (s *StatusSyncer) updateNodeStatus(ctx context.Context, cli client.Client, 
 		node.Message = ""
 
 		if err := s.updateNodeRaftStatus(node); err != nil {
-			return err
+			log.Error(err, "failed to get/update node raft status", "node", node.Name)
+			node.Message = err.Error()
 		}
 
 		isLagged, isReplicating, isReadOnly := corev1.ConditionUnknown, corev1.ConditionUnknown, corev1.ConditionUnknown
@@ -296,19 +297,24 @@ func (s *StatusSyncer) updateNodeCondition(node *apiv1alpha1.NodeStatus, idx int
 
 // updateNodeRaftStatus Update Node RaftStatus.
 func (s *StatusSyncer) updateNodeRaftStatus(node *apiv1alpha1.NodeStatus) error {
-	raftStatus, err := s.XenonExecutor.RaftStatus(node.Name)
-	if err != nil {
-		return err
-	}
-	node.RaftStatus = *raftStatus
-
 	isLeader := corev1.ConditionFalse
-	if node.RaftStatus.Role == string(utils.Leader) {
-		isLeader = corev1.ConditionTrue
+	node.RaftStatus = apiv1alpha1.RaftStatus{
+		Role:   string(utils.Unknown),
+		Leader: "UNKNOWN",
+		Nodes:  nil,
 	}
+
+	raftStatus, err := s.XenonExecutor.RaftStatus(node.Name)
+	if err == nil && raftStatus != nil {
+		node.RaftStatus = *raftStatus
+		if raftStatus.Role == string(utils.Leader) {
+			isLeader = corev1.ConditionTrue
+		}
+	}
+
 	// update apiv1alpha1.NodeConditionLeader.
 	s.updateNodeCondition(node, int(apiv1alpha1.IndexLeader), isLeader)
-	return nil
+	return err
 }
 
 func (s *StatusSyncer) reconcileXenon(readyNodes int) error {

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -166,6 +166,7 @@ const (
 	Leader    RaftRole = "LEADER"
 	Follower  RaftRole = "FOLLOWER"
 	Candidate RaftRole = "CANDIDATE"
+	Unknown   RaftRole = "UNKNOWN"
 )
 
 // XenonHttpUrl is a http url corresponding to the xenon instruction.


### PR DESCRIPTION
### What type of PR is this?

/bug

### Which issue(s) this PR fixes?

Fixes #417

### What this PR does?

Summary:

- Do not return err when operator cannot connect to node.
- Provide a default status which is used to unavailable node.

### Special notes for your reviewer?

for test: 
```
helm upgrade demo radondb/mysql-operator --install --set manager.image=runkecheng/mysql-operator --set manager.tag=t0317b
```