### PR TITLE
*: Optimize mysql8 related logic.

### DIFF
--- a/api/v1alpha1/mysqlcluster_types.go
+++ b/api/v1alpha1/mysqlcluster_types.go
@@ -120,7 +120,7 @@ type MysqlOpts struct {
 
 	// InitTokuDB represents if install tokudb engine.
 	// +optional
-	// +kubebuilder:default:=true
+	// +kubebuilder:default:=false
 	InitTokuDB bool `json:"initTokuDB,omitempty"`
 
 	// A map[string]string that will be passed to my.cnf file.

--- a/charts/mysql-operator/crds/mysql.radondb.com_backups.yaml
+++ b/charts/mysql-operator/crds/mysql.radondb.com_backups.yaml
@@ -48,7 +48,7 @@ spec:
                 description: HostName represents the host for which to take backup
                 type: string
               image:
-                default: radondb/mysql-sidecar:latest
+                default: radondb/mysql57-sidecar:v2.2.0
                 description: To specify the image that will be used for sidecar container.
                 type: string
             required:

--- a/charts/mysql-operator/crds/mysql.radondb.com_mysqlclusters.yaml
+++ b/charts/mysql-operator/crds/mysql.radondb.com_mysqlclusters.yaml
@@ -137,7 +137,7 @@ spec:
                     description: Name for new database to create.
                     type: string
                   initTokuDB:
-                    default: true
+                    default: false
                     description: InitTokuDB represents if install tokudb engine.
                     type: boolean
                   mysqlConf:
@@ -252,7 +252,7 @@ spec:
                       cpu: 10m
                       memory: 32Mi
                   imagePullPolicy: IfNotPresent
-                  sidecarImage: radondb/mysql-sidecar:latest
+                  sidecarImage: radondb/mysql57-sidecar:v2.2.0
                 description: PodPolicy defines the policy to extra specification.
                 properties:
                   affinity:
@@ -1182,7 +1182,7 @@ spec:
                   schedulerName:
                     type: string
                   sidecarImage:
-                    default: radondb/mysql-sidecar:latest
+                    default: radondb/mysql57-sidecar:v2.2.0
                     description: To specify the image that will be used for sidecar
                       container.
                     type: string

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -21,7 +21,7 @@ tolerationSeconds: 30
 
 manager:
   image: radondb/mysql-operator
-  tag: latest
+  tag: v2.2.0
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/config/samples/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/samples/mysql_v1alpha1_mysqlcluster.yaml
@@ -62,7 +62,7 @@ spec:
 
   podPolicy:
     imagePullPolicy: IfNotPresent
-    sidecarImage: radondb/mysql-sidecar:latest
+    sidecarImage: radondb/mysql57-sidecar:v2.2.0
     busyboxImage: busybox:1.32
 
     slowLogTail: false

--- a/config/samples/mysql_v1alpha1_mysqlcluster_mysql8.yaml
+++ b/config/samples/mysql_v1alpha1_mysqlcluster_mysql8.yaml
@@ -1,27 +1,33 @@
 apiVersion: mysql.radondb.com/v1alpha1
 kind: MysqlCluster
 metadata:
-  name: mysql8-sample
+  name: sample
 spec:
   replicas: 3
   mysqlVersion: "8.0"
+  
   # the backupSecretName specify the secret file name which store S3 information,
   # if you want S3 backup or restore, please create backup_secret.yaml, uncomment below and fill secret name:
   # backupSecretName: 
-
+  
   # if you want create mysqlcluster from S3, uncomment and fill the directory in S3 bucket below:
-  # restoreFrom: "backup_2022324174848"
+  # restoreFrom: 
+  
   mysqlOpts:
     rootPassword: "RadonDB@123"
     rootHost: localhost
     user: radondb_usr
     password: RadonDB@123
     database: radondb
+    ## tokudb is not supported in mysql8.
+    # initTokuDB: false
+
     # A simple map between string and string.
     # Such as:
     #    mysqlConf:
     #      expire_logs_days: "7"
     mysqlConf: {}
+
     resources:
       requests:
         cpu: 100m
@@ -29,10 +35,12 @@ spec:
       limits:
         cpu: 500m
         memory: 1Gi
+
   xenonOpts:
     image: radondb/xenon:1.1.5-alpha
     admitDefeatHearbeatCount: 5
     electionTimeout: 10000
+
     resources:
       requests:
         cpu: 50m
@@ -40,9 +48,11 @@ spec:
       limits:
         cpu: 100m
         memory: 256Mi
+
   metricsOpts:
     enabled: false
     image: prom/mysqld-exporter:v0.12.1
+
     resources:
       requests:
         cpu: 10m
@@ -50,12 +60,15 @@ spec:
       limits:
         cpu: 100m
         memory: 128Mi
+
   podPolicy:
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     sidecarImage: radondb/mysql80-sidecar:v2.2.0
     busyboxImage: busybox:1.32
+
     slowLogTail: false
     auditLogTail: false
+
     labels: {}
     annotations: {}
     affinity: {}
@@ -67,10 +80,10 @@ spec:
       requests:
         cpu: 10m
         memory: 32Mi
+
   persistence:
     enabled: true
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     #storageClass: ""
     size: 20Gi
-  backupSecretName: sample-backup-secret

--- a/config/samples/mysql_v1alpha1_mysqlcluster_podAntiAffinity.yaml
+++ b/config/samples/mysql_v1alpha1_mysqlcluster_podAntiAffinity.yaml
@@ -62,7 +62,7 @@ spec:
 
   podPolicy:
     imagePullPolicy: IfNotPresent
-    sidecarImage: radondb/mysql-sidecar:latest
+    sidecarImage: radondb/mysql57-sidecar:v2.2.0
     busyboxImage: busybox:1.32
 
     slowLogTail: false

--- a/mysqlcluster/syncer/config_map.go
+++ b/mysqlcluster/syncer/config_map.go
@@ -51,13 +51,13 @@ func NewConfigMapSyncer(cli client.Client, c *mysqlcluster.MysqlCluster) syncer.
 			return fmt.Errorf("failed to create mysql configs: %s", err)
 		}
 
-		dataSpecial, err := buildMysqlSpecialConf(c)
+		dataPlugin, err := buildMysqlPluginConf(c)
 		if err != nil {
-			return fmt.Errorf("failed to create mysql special configs: %s", err)
+			return fmt.Errorf("failed to create mysql plugin configs: %s", err)
 		}
 		cm.Data = map[string]string{
 			"my.cnf":            data,
-			utils.SpecialConfig: dataSpecial,
+			utils.PluginConfigs: dataPlugin,
 		}
 
 		return nil
@@ -70,10 +70,14 @@ func buildMysqlConf(c *mysqlcluster.MysqlCluster) (string, error) {
 	sec := cfg.Section("mysqld")
 
 	c.EnsureMysqlConf()
-	if c.Spec.MysqlVersion == "8.0" {
-		delete(mysqlCommonConfigs, "query_cache_size")
-		delete(mysqlStaticConfigs, "query_cache_type")
+
+	switch c.Spec.MysqlVersion {
+	case "8.0":
+		addKVConfigsToSection(sec, mysql80Configs)
+	case "5.7":
+		addKVConfigsToSection(sec, mysql57Configs)
 	}
+	
 	addKVConfigsToSection(sec, mysqlSysConfigs, mysqlCommonConfigs, mysqlStaticConfigs, c.Spec.MysqlOpts.MysqlConf)
 
 	if c.Spec.MysqlOpts.InitTokuDB {
@@ -94,12 +98,12 @@ func buildMysqlConf(c *mysqlcluster.MysqlCluster) (string, error) {
 	return data, nil
 }
 
-// Build the Special Cnf file.
-func buildMysqlSpecialConf(c *mysqlcluster.MysqlCluster) (string, error) {
+// Build the Plugin Cnf file.
+func buildMysqlPluginConf(c *mysqlcluster.MysqlCluster) (string, error) {
 	cfg := ini.Empty(ini.LoadOptions{IgnoreInlineComment: true})
 	sec := cfg.Section("mysqld")
 
-	addKVConfigsToSection(sec, specialConfigs)
+	addKVConfigsToSection(sec, pluginConfigs)
 	data, err := writeConfigs(cfg)
 	if err != nil {
 		return "", err

--- a/mysqlcluster/syncer/mysql_configs.go
+++ b/mysqlcluster/syncer/mysql_configs.go
@@ -40,31 +40,52 @@ var mysqlSysConfigs = map[string]string{
 	"slave_parallel_type":       "LOGICAL_CLOCK",
 	"relay_log":                 "/var/lib/mysql/mysql-relay-bin",
 	"relay_log_index":           "/var/lib/mysql/mysql-relay-bin.index",
-	"master_info_repository":    "TABLE",
-	"relay_log_info_repository": "TABLE",
 	"slow_query_log":            "1",
 	"tmp_table_size":            "32M",
 	"tmpdir":                    "/var/lib/mysql",
 }
 
-var specialConfigs = map[string]string{
+var pluginConfigs = map[string]string{
 	"plugin-load":                        "\"semisync_master.so;semisync_slave.so;audit_log.so;connection_control.so\"",
-	"audit_log_file":                     "/var/log/mysql/mysql-audit.log",
-	"audit_log_exclude_accounts":         "\"root@localhost,root@127.0.0.1," + utils.ReplicationUser + "@%," + utils.MetricsUser + "@%\"",
-	"audit_log_buffer_size":              "16M",
+
 	"rpl_semi_sync_master_enabled":       "OFF",
 	"rpl_semi_sync_slave_enabled":        "ON",
 	"rpl_semi_sync_master_wait_no_slave": "ON",
 	"rpl_semi_sync_master_timeout":       "1000000000000000000",
-	//"audit-log":                                       "ON",
+
+	"audit_log_file":                     "/var/log/mysql/mysql-audit.log",
+	"audit_log_exclude_accounts":         "\"root@localhost,root@127.0.0.1," + utils.ReplicationUser + "@%," + utils.MetricsUser + "@%\"",
+	"audit_log_buffer_size":              "16M",
 	"audit_log_policy":                                "NONE",
 	"audit_log_rotate_on_size":                        "104857600",
 	"audit_log_rotations":                             "6",
 	"audit_log_format":                                "OLD",
+
 	"connection_control_failed_connections_threshold": "3",
 	"connection_control_min_connection_delay":         "1000",
 	"connection_control_max_connection_delay":         "2147483647",
-	"default-authentication-plugin":                   "mysql_native_password",
+}
+
+var mysql57Configs = map[string]string{
+	"query-cache-type": "0",
+	"query-cache-size": "0",
+	"sql-mode": "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER," +
+		"NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY",
+
+	"expire-logs-days": "7",
+
+	"master_info_repository":    "TABLE",
+	"relay_log_info_repository": "TABLE",
+	"slave_rows_search_algorithms":    "INDEX_SCAN,HASH_SCAN",
+}
+
+var mysql80Configs = map[string]string{
+	"sql-mode": "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION," +
+	"NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY",
+	// 7 days = 7 * 24 * 60 * 60
+	"binlog_expire_logs_seconds": "604800", 
+	// use 5.7 auth plugin to be backward compatible
+	"default-authentication-plugin": "mysql_native_password",
 }
 
 // mysqlCommonConfigs is the map of the mysql common configs.
@@ -72,7 +93,6 @@ var mysqlCommonConfigs = map[string]string{
 	"character_set_server":            "utf8mb4",
 	"interactive_timeout":             "3600",
 	"default-time-zone":               "+08:00",
-	"expire_logs_days":                "7",
 	"key_buffer_size":                 "33554432",
 	"log_bin_trust_function_creators": "1",
 	"long_query_time":                 "3",
@@ -80,7 +100,6 @@ var mysqlCommonConfigs = map[string]string{
 	"binlog_stmt_cache_size":          "32768",
 	"max_connections":                 "1024",
 	"max_connect_errors":              "655360",
-	"query_cache_size":                "0",
 	"sync_master_info":                "1000",
 	"sync_relay_log":                  "1000",
 	"sync_relay_log_info":             "1000",
@@ -88,7 +107,6 @@ var mysqlCommonConfigs = map[string]string{
 	"thread_cache_size":               "128",
 	"wait_timeout":                    "3600",
 	"group_concat_max_len":            "1024",
-	"slave_rows_search_algorithms":    "INDEX_SCAN,HASH_SCAN",
 	"max_allowed_packet":              "1073741824",
 	"event_scheduler":                 "OFF",
 	"innodb_print_all_deadlocks":      "0",
@@ -102,12 +120,10 @@ var mysqlCommonConfigs = map[string]string{
 // mysqlStaticConfigs is the map of the mysql static configs.
 // The mysql need restart, if modify the config.
 var mysqlStaticConfigs = map[string]string{
-
 	"default-storage-engine":      "InnoDB",
 	"back_log":                    "2048",
 	"ft_min_word_len":             "4",
 	"lower_case_table_names":      "0",
-	"query_cache_type":            "OFF",
 	"innodb_ft_max_token_size":    "84",
 	"innodb_ft_min_token_size":    "3",
 	"sql_mode":                    "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION",

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -132,8 +132,8 @@ const (
 	// LeaderHost is the alias for leader`s host.
 	LeaderHost = "leader-host"
 
-	// For MySQL8, the configs should deal with alone
-	SpecialConfig = "special.cnf"
+	// 
+	PluginConfigs = "plugin.cnf"
 )
 
 // ResourceName is the type for aliasing resources that will be created.


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #

### What this PR does?

Summary:

- Set the default value of InitTokuDB to false.
- Separate the configuration of mysql57 and mysql80, remove partially discarded parameters.
- Package the logic of applying configuration to improve code readability.

Some parameters of MySQL57 have been discarded in mysql8.
```
// MySQL init process in progress...

// 2022-04-06T17:05:40.140140+08:00 0 [Warning] [MY-011069] [Server] The syntax '--master-info-repository' is deprecated and will be removed in a future release.

// 2022-04-06T17:05:40.140167+08:00 0 [Warning] [MY-011069] [Server] The syntax '--relay-log-info-repository' is deprecated and will be removed in a future release.

// 2022-04-06T17:05:40.140195+08:00 0 [Warning] [MY-011068] [Server] The syntax 'expire-logs-days' is deprecated and will be removed in a future release. Please use binlog_expire_logs_seconds instead.

// 2022-04-06T17:05:40.140767+08:00 0 [Warning] [MY-011069] [Server] The syntax '--slave-rows-search-algorithms' is deprecated and will be removed in a future release.

// 2022-04-06T17:05:40.140833+08:00 0 [Warning] [MY-010086] [Server] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).

// 2022-04-06T17:05:40.140857+08:00 0 [Warning] [MY-010915] [Server] 'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.

// 2022-04-06T17:05:40.142529+08:00 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.25-15) starting as process 65

// 2022-04-06T17:05:40.152588+08:00 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
```

### Special notes for your reviewer?
