### PR TITLE
ci: Fix `build-arg` not take effect.

### DIFF
--- a/.github/workflows/build_sidecar_image.yml
+++ b/.github/workflows/build_sidecar_image.yml
@@ -48,4 +48,4 @@ jobs:
           push: true
           file: Dockerfile.sidecar
           tags: radondb/${{ matrix.version }}-sidecar:${{ inputs.image_tag }}
-          build-args: --build-arg XTRABACKUP_PKG=percona-xtrabackup-80
+          build-args: XTRABACKUP_PKG=percona-xtrabackup-80


### PR DESCRIPTION
### What type of PR is this?

/bug

### Which issue(s) this PR fixes?

Fixes #460

This instruction has more` --build-arg`, but runs successfully in CI, which causes the image that are produced and does not use `--build-arg`.
```
/usr/bin/docker buildx build --build-arg --build-arg XTRABACKUP_PKG=percona-xtrabackup-80 --file Dockerfile.sidecar --iidfile /tmp/docker-build-push-WFnJFw/iidfile

backup container: 
$ xtrabackup -v
xtrabackup version 2.4.24 based on MySQL server 5.7.35 Linux (x86_64) (revision id: b4ee263)
```

### What this PR does?

Summary:


### Special notes for your reviewer?
