### PR TITLE
syncer: Reduce useless log output #508

### DIFF
--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -89,12 +89,13 @@ func (r *MysqlClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	status := *instance.Status.DeepCopy()
+	oldInstance := instance.DeepCopy()
 	defer func() {
-		if !reflect.DeepEqual(status, instance.Status) {
-			sErr := r.Status().Update(ctx, instance.Unwrap())
+		// TODO: Remove Status().Patch in mysqlcluster controller.
+		if !reflect.DeepEqual(oldInstance.Status, instance.Status) {
+			sErr := r.Status().Patch(ctx, instance.Unwrap(), client.MergeFrom(oldInstance))
 			if sErr != nil {
-				log.Error(sErr, "failed to update cluster status")
+				log.V(1).Info("failed to update cluster status", "error", sErr)
 			}
 		}
 	}()

--- a/controllers/status_controller.go
+++ b/controllers/status_controller.go
@@ -84,12 +84,12 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, err
 	}
 
-	status := *instance.Status.DeepCopy()
+	oldInstance := instance.DeepCopy()
 	defer func() {
-		if !reflect.DeepEqual(status, instance.Status) {
-			sErr := r.Status().Update(ctx, instance.Unwrap())
+		if !reflect.DeepEqual(oldInstance.Status, instance.Status) {
+			sErr := r.Status().Patch(ctx, instance.Unwrap(), client.MergeFrom(oldInstance))
 			if sErr != nil {
-				log.Error(sErr, "failed to update cluster status")
+				log.V(1).Info("failed to update cluster status", "error", sErr)
 			}
 		}
 	}()

--- a/mysqlcluster/syncer/statefulset.go
+++ b/mysqlcluster/syncer/statefulset.go
@@ -482,9 +482,9 @@ func (s *StatefulSetSyncer) applyNWait(ctx context.Context, pod *corev1.Pod) err
 		s.log.Info("pod is already updated", "pod name", pod.Name)
 	} else {
 		s.Status.State = apiv1alpha1.ClusterUpdateState
-		s.log.Info("updating pod", "pod", pod.Name, "key", s.Unwrap())
+		s.log.Info("updating pod", "pod", pod.Name)
 		if pod.DeletionTimestamp != nil {
-			s.log.Info("pod is being deleted", "pod", pod.Name, "key", s.Unwrap())
+			s.log.Info("pod is being deleted", "pod", pod.Name)
 		} else {
 			// If healthy is always `yes`, retry() will exit in advance, which may
 			// cause excessive nodes are deleted at the same time, details: issue#310.
@@ -510,7 +510,7 @@ func (s *StatefulSetSyncer) applyNWait(ctx context.Context, pod *corev1.Pod) err
 			return false, err
 		}
 		if ordinal >= int(*s.Spec.Replicas) {
-			s.log.Info("replicas were changed,  should skip", "pod", pod.Name)
+			s.log.Info("replicas were changed, should skip", "pod", pod.Name)
 			return true, nil
 		}
 

--- a/mysqlcluster/syncer/status.go
+++ b/mysqlcluster/syncer/status.go
@@ -240,7 +240,7 @@ func (s *StatusSyncer) updateNodeStatus(ctx context.Context, cli client.Client, 
 		node.Message = ""
 
 		if err := s.updateNodeRaftStatus(node); err != nil {
-			s.log.Error(err, "failed to get/update node raft status", "node", node.Name)
+			s.log.V(1).Info("failed to get/update node raft status", "node", node.Name, "error", err)
 			node.Message = err.Error()
 		}
 
@@ -249,18 +249,18 @@ func (s *StatusSyncer) updateNodeStatus(ctx context.Context, cli client.Client, 
 			s.cli, s.MysqlCluster.GetClusterKey(), utils.OperatorUser, host))
 		defer closeConn()
 		if err != nil {
-			s.log.Error(err, "failed to connect the mysql", "node", node.Name)
+			s.log.V(1).Info("failed to connect the mysql", "node", node.Name, "error", err)
 			node.Message = err.Error()
 		} else {
 			isLagged, isReplicating, err = internal.CheckSlaveStatusWithRetry(sqlRunner, checkNodeStatusRetry)
 			if err != nil {
-				s.log.Error(err, "failed to check slave status", "node", node.Name)
+				s.log.V(1).Info("failed to check slave status", "node", node.Name, "error", err)
 				node.Message = err.Error()
 			}
 
 			isReadOnly, err = internal.CheckReadOnly(sqlRunner)
 			if err != nil {
-				s.log.Error(err, "failed to check read only", "node", node.Name)
+				s.log.V(1).Info("failed to check read only", "node", node.Name, "error", err)
 				node.Message = err.Error()
 			}
 
@@ -281,7 +281,7 @@ func (s *StatusSyncer) updateNodeStatus(ctx context.Context, cli client.Client, 
 		s.updateNodeCondition(node, int(apiv1alpha1.IndexReadOnly), isReadOnly)
 
 		if err = s.updatePodLabel(ctx, &pod, node); err != nil {
-			s.log.Error(err, "failed to update labels", "pod", pod.Name, "namespace", pod.Namespace)
+			s.log.V(1).Info("failed to update labels", "pod", pod.Name, "error", err)
 		}
 	}
 


### PR DESCRIPTION
### What type of PR is this?

/cleanup
### Which issue(s) this PR fixes?

1. status.go: adjust the log level(ERROR->DEBUG)
2. statefulset.go: remove unnecessary output items

fix: #508

### What this PR does?

Summary:

### Special notes for your reviewer?
