### PR TITLE
mysqlcluster: innodb_log_file_size auto config. #501

### DIFF
--- a/mysqlcluster/mysqlcluster.go
+++ b/mysqlcluster/mysqlcluster.go
@@ -36,6 +36,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/go-logr/logr"
+
 	apiv1alpha1 "github.com/radondb/radondb-mysql-kubernetes/api/v1alpha1"
 	"github.com/radondb/radondb-mysql-kubernetes/utils"
 )
@@ -361,6 +362,49 @@ func (c *MysqlCluster) EnsureMysqlConf() {
 	instances := math.Max(math.Min(math.Ceil(float64(cpu)/float64(1000)), math.Floor(float64(innodbBufferPoolSize)/float64(gb))), 1)
 	c.Spec.MysqlOpts.MysqlConf["innodb_buffer_pool_size"] = strconv.FormatUint(innodbBufferPoolSize, 10)
 	c.Spec.MysqlOpts.MysqlConf["innodb_buffer_pool_instances"] = strconv.Itoa(int(instances))
+
+	// innodb_log_file_size = 25 % of innodb_buffer_pool_size
+	// Minimum Value (≥ 5.7.11)	4194304
+	// Minimum Value (≤ 5.7.10)	1048576
+	// Maximum Value	512GB / innodb_log_files_in_group
+	// but wet set it not over than 8G, you should set it in the config file when you want over 8G.
+	// See https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_log_file_size
+
+	const innodbDefaultLogFileSize uint64 = 1073741824
+	var innodbLogFileSize uint64 = innodbDefaultLogFileSize // 1GB, default value
+	// if innodb_log_file_size is not set, calculate it
+	if _, ok := c.Spec.MysqlOpts.MysqlConf["innodb_log_file_size"]; !ok {
+		logGroups, err := strconv.Atoi(c.Spec.MysqlOpts.MysqlConf["innodb_log_file_groups"])
+		if err != nil {
+			logGroups = 1
+		}
+
+		// https://dev.mysql.com/doc/refman/8.0/en/innodb-dedicated-server.html
+		// Table 15.9 Automatically Configured Log File Size
+		// Buffer Pool Size	Log File Size
+		// Less than 8GB	512MiB
+		// 8GB to 128GB	1024MiB
+		// Greater than 128GB	2048MiB
+		if innodbBufferPoolSize < (8 * gb) {
+			innodbLogFileSize = (512 * mb) / (uint64(logGroups))
+		} else if innodbBufferPoolSize <= (128 * gb) {
+			innodbLogFileSize = 1 * gb
+		} else {
+			innodbLogFileSize = 2 * gb
+		}
+		// Check if the innodb_log_file_size is bigger than persistent volume size
+		q, err := resource.ParseQuantity(c.Spec.Persistence.Size)
+		if err != nil {
+			c.log.Error(err, "failed to parse persistent volume size")
+		} else {
+			if uint64(q.Value()/2) < innodbLogFileSize {
+				c.log.Error(err, "log file size too larger than persistent volume size")
+				innodbLogFileSize = innodbDefaultLogFileSize
+			}
+			c.Spec.MysqlOpts.MysqlConf["innodb_log_file_size"] = strconv.FormatUint(innodbLogFileSize, 10)
+		}
+
+	}
 }
 
 // sizeToBytes parses a string formatted by ByteSize as bytes.

--- a/mysqlcluster/syncer/mysql_configs.go
+++ b/mysqlcluster/syncer/mysql_configs.go
@@ -129,12 +129,12 @@ var mysqlStaticConfigs = map[string]string{
 	"slave_parallel_workers":      "8",
 	"slave_pending_jobs_size_max": "1073741824",
 	"innodb_log_buffer_size":      "16777216",
-	"innodb_log_file_size":        "1073741824",
-	"innodb_log_files_in_group":   "2",
-	"innodb_flush_method":         "O_DIRECT",
-	"innodb_use_native_aio":       "1",
-	"innodb_autoinc_lock_mode":    "2",
-	"performance_schema":          "1",
+	//"innodb_log_file_size":        "1073741824",
+	"innodb_log_files_in_group": "2",
+	"innodb_flush_method":       "O_DIRECT",
+	"innodb_use_native_aio":     "1",
+	"innodb_autoinc_lock_mode":  "2",
+	"performance_schema":        "1",
 }
 
 // mysqlTokudbConfigs is the map of the mysql tokudb configs.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed #xxx
2. *: what's changed #xxx

-->

### What type of PR is this?

<!--
Add one of the following types:
/bug
/documentation
/cleanup

-->
/enhancement
### Which issue(s) this PR fixes?

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #501 

### What this PR does?

Summary:
1. When the redo log file size is not set manually, auto set  redo log file size is  25% of innodb_buffer_pool_size , but never over 8G.
2. when users want set over 8G,  they should set it in yaml file manually.
### Special notes for your reviewer?
