### PR TITLE
chart: Support the use of Helm to install MySQL cluster

### DIFF
--- a/charts/mysql-operator/charts/mysql-cluster/.helmignore
+++ b/charts/mysql-operator/charts/mysql-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mysql-operator/charts/mysql-cluster/Chart.yaml
+++ b/charts/mysql-operator/charts/mysql-cluster/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mysqlcluster
+description: A Helm chart for installing radondb mysql cluster.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 2.2.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2.2.1"

--- a/charts/mysql-operator/charts/mysql-cluster/templates/NOTES.txt
+++ b/charts/mysql-operator/charts/mysql-cluster/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Welcome to RadonDB MySQL Kubernetes!
+
+Connect to the database:
+
+kubectl exec -it svc/{{ .Values.name }}-leader -c mysql -- mysql -u{{ .Values.superUser.name }} -p{{ .Values.superUser.password }}
+
+Change password:
+
+kubectl patch secret {{ .Values.name }}-user-password --patch="{\"data\": { \"{{ .Values.superUser.name }}\": \"$(echo -n <yourpass> |base64 -w0)\" }}" -oyaml
+
+Github: https://github.com/radondb/radondb-mysql-kubernetes

--- a/charts/mysql-operator/charts/mysql-cluster/templates/_helpers.tpl
+++ b/charts/mysql-operator/charts/mysql-cluster/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{- define "cluster.name" -}}
+{{- default .Release.Name .Values.name }}
+{{- end }}
+
+{{- define "images.sidecar" -}}
+{{ ternary (printf "radondb/mysql80-sidecar:%s" .Values.version ) (printf "radondb/mysql57-sidecar:%s" .Values.version ) (eq .Values.mysqlVersion "8.0") }}
+{{- end }}
+
+{{- define "user.secret.name" -}}
+{{ "sample-user-password" }}
+{{- end }}
+
+{{- define "user.cr.name" -}}
+{{ printf "%s-%s-%s" ( include "cluster.name" . ) .Release.Namespace (.Values.superUser.name | replace "_" "-") }}
+{{- end }}
+
+{{- define "schedule.disable" }}
+{{- and (not .Values.schedule.podAntiaffinity) (not .Values.schedule.nodeSelector) }}
+{{- end }}
+
+{{- define "tls.server.secret" -}}
+{{ printf "%s-%s-%s" ( include "cluster.name" . ) .Release.Namespace "tls-server" }}
+{{- end }}
+
+{{- define "tls.client.secret" -}}
+{{ printf "%s-%s-%s" ( include "cluster.name" . ) .Release.Namespace "tls-client" }}
+{{- end }}
+
+{{- define "cluster.tls.secret.name" -}}
+{{- if (and .Values.tls.enable (empty .Values.tls.secretName)) -}}
+    {{ include "tls.server.secret" . }}
+{{- else -}}
+    {{ .Values.tls.secretName }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mysql-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mysql-cluster.labels" }}
+app.kubernetes.io/name: {{ include "cluster.name" . }}
+helm.sh/chart: {{ include "mysql-cluster.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/mysql-operator/charts/mysql-cluster/templates/cert.tpl
+++ b/charts/mysql-operator/charts/mysql-cluster/templates/cert.tpl
@@ -1,0 +1,30 @@
+## CA
+{{- define "tls.ca" -}}
+  {{- /* Generate ca with CN "radondb-ca" and 5 years validity duration if not exists in the current scope.*/ -}}
+  {{- $caKeypair := genCA "radondb-ca" 1825 -}}
+  {{- $_ := set . "selfSignedCAKeypair" $caKeypair -}}
+  {{- $caKeypair.Cert -}}
+{{- end -}}
+## Server
+{{- define "server.certPEM" -}}
+  {{- $CA := required "self-signed CA keypair is requried" .selfSignedCAKeypair -}}
+  {{- /* genSignedCert <CN> <IP> <DNS> <Validity duration> <CA> */ -}}
+  {{- $ServerTLSKeypair := genSignedCert "radondb-mysql-server" nil nil 1825 $CA -}}
+  {{- $_ := set . "serverTLSKeypair" $ServerTLSKeypair -}}
+  {{- $ServerTLSKeypair.Cert -}}
+{{- end -}}
+{{- define "server.keyPEM" -}}
+    {{- .serverTLSKeypair.Key -}}
+{{- end -}}
+## Client
+{{- define "client.certPEM" -}}
+  {{- $CA := required "self-signed CA keypair is requried" .selfSignedCAKeypair -}}
+  {{- /* genSignedCert <CN> <IP> <DNS> <Validity duration> <CA> */ -}}
+  {{- $ClientTLSKeypair := genSignedCert "radondb-mysql-client" nil nil 1825 $CA -}}
+  {{- $_ := set . "clientTLSKeypair" $ClientTLSKeypair -}}
+  {{- $ClientTLSKeypair.Cert -}}
+{{- end -}}
+{{- define "client.keyPEM" -}}
+    {{- .clientTLSKeypair.Key -}}
+{{- end -}}
+

--- a/charts/mysql-operator/charts/mysql-cluster/templates/mysqlcluster.yaml
+++ b/charts/mysql-operator/charts/mysql-cluster/templates/mysqlcluster.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.install }}
+{{- $scheduleDisable := include "schedule.disable" . }}
+apiVersion: mysql.radondb.com/v1alpha1
+kind: MysqlCluster
+metadata:
+  name: {{ template "cluster.name" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  replicas: {{ .Values.replicas }}
+  mysqlVersion: {{ ternary "8.0" "5.7" (eq .Values.mysqlVersion "8.0") | quote }}
+  tlsSecretName: {{ include "cluster.tls.secret.name" . }}
+
+  mysqlOpts:
+    {{- with .Values.mycnf }}
+    mysqlConf:
+    {{ toYaml . | indent 6 }}
+    {{- end }}
+
+    resources:
+      limits:
+        cpu: {{ .Values.mysqlResources.limits.cpu }}
+        memory: {{ .Values.mysqlResources.limits.memory }}
+      requests:
+        cpu: {{ .Values.mysqlResources.requests.cpu }}
+        memory: {{ .Values.mysqlResources.requests.memory }}
+
+  metricsOpts:
+    enabled: {{ .Values.sidecar.metrics }}
+
+  podPolicy:
+    sidecarImage: {{ template "images.sidecar" . }}
+
+    slowLogTail: {{ .Values.sidecar.slowLogTail }}
+    auditLogTail: {{ .Values.sidecar.auditLogTail }}
+
+    labels: {}
+    annotations: {}
+    {{- if $scheduleDisable }}
+    affinity: {}
+    {{- else }}
+    affinity:
+    {{- if .Values.schedule.podAntiaffinity }}
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: mysql.radondb.com/cluster
+              operator: In
+              values:
+              - {{ .Values.mysqlCluster.name }}
+          topologyKey: "kubernetes.io/hostname"
+    {{- if .Values.schedule.nodeSelector }}
+      nodeSelector:
+        {{- range $k, $v := .Values.schedule.nodeSelector }}
+          {{ $k }}: {{ $v }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+
+    priorityClassName: ""
+    tolerations: {{ .Values.schedule.tolerations }}
+    schedulerName: ""
+
+  persistence:
+    enabled: true
+    accessModes:
+    - ReadWriteOnce
+    {{- if .Values.persistence.storageClass }}
+    storageClass: {{ .Values.persistence.storageClass }}
+    {{- end }}
+    size: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/mysql-operator/charts/mysql-cluster/templates/mysqluser.yaml
+++ b/charts/mysql-operator/charts/mysql-cluster/templates/mysqluser.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.install }}
+{{- if .Values.superUser.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "user.secret.name" . }}
+data:
+  {{ .Values.superUser.name }}: {{ .Values.superUser.password | b64enc }}
+---
+apiVersion: mysql.radondb.com/v1alpha1
+kind: MysqlUser
+metadata:
+  name: {{ template "user.cr.name" . }}
+spec:
+  user: {{ .Values.superUser.name }}
+  withGrantOption: true
+  tlsOptions: 
+    type: {{ .Values.superUser.tlsType }}
+  hosts: 
+    - "%"
+  permissions:
+    - database: "*"
+      tables:
+        - "*"
+      privileges:
+        - ALL
+  userOwner:
+    clusterName: {{ template "cluster.name" . }}
+    nameSpace: {{ .Values.namespace }}
+  secretSelector:
+    secretName: {{ template "user.secret.name" . }}
+    secretKey: {{ .Values.superUser.name }}
+{{- end }}
+{{- end }}

--- a/charts/mysql-operator/charts/mysql-cluster/templates/tls_secrets.yaml
+++ b/charts/mysql-operator/charts/mysql-cluster/templates/tls_secrets.yaml
@@ -1,0 +1,39 @@
+{{- if (and .Values.tls.enable (empty .Values.tls.secretName)) -}}
+
+{{- $caCertPEM := include "tls.ca" . -}}
+{{- $serverCertPEM := include "server.certPEM" . -}}
+{{- $serverKeyPEM := include "server.keyPEM" . -}}
+{{- $clientCertPEM := include "client.certPEM" . -}}
+{{- $clientKeyPEM := include "client.keyPEM" . -}}
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "tls.server.secret" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mysql-cluster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql-tls-secret
+type: Opaque
+data:
+  ca.crt: {{ b64enc $caCertPEM }}
+  tls.crt: {{ b64enc $serverCertPEM }}
+  tls.key: {{ b64enc $serverKeyPEM }}
+
+---
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "tls.client.secret" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mysql-cluster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql-tls-secret
+type: Opaque
+data:
+  ca.crt: {{ b64enc $caCertPEM }}
+  tls.crt: {{ b64enc $clientCertPEM }}
+  tls.key: {{ b64enc $clientKeyPEM }}
+
+{{- end }}

--- a/charts/mysql-operator/charts/mysql-cluster/values.yaml
+++ b/charts/mysql-operator/charts/mysql-cluster/values.yaml
@@ -1,0 +1,43 @@
+install: true
+
+replicas: 3
+
+name: "sample"
+namespace: "default"
+
+mysqlVersion: "8.0"
+version: v2.2.1
+
+tls: 
+  enable: false
+  secretName: ""
+
+sidecar:
+  metrics: false
+  slowLogTail: false
+  auditLogTail: false
+
+schedule:
+  podAntiaffinity: true
+  nodeSelector: {}
+  tolerations: []
+
+persistence:
+  storageClass: ""
+  size: 20Gi
+
+mysqlResources:
+  limits:
+    cpu: 256m
+    memory: 500Mi
+  requests:
+    cpu: 256m
+    memory: 500Mi
+
+mycnf: {}
+
+superUser:
+  create: true
+  name: "super_usr"
+  password: "RadonDB@123"
+  tlsType: NONE 

--- a/charts/mysql-operator/templates/NOTES.txt
+++ b/charts/mysql-operator/templates/NOTES.txt
@@ -1,10 +1,31 @@
-You can create a new mysqlcluster by issuing:
+Welcome to RadonDB MySQL Kubernetes!
 
-cat <<EOF | kubectl apply -f-
-apiVersion: mysql.radondb.com/v1alpha1
-kind: MysqlCluster
-metadata:
-  name: sample
-spec:
-  replicas: 3
-EOF
+{{- if .Values.mysqlcluster.install }}
+
+Create MySQLCluster:
+{{- else }}
+
+> Create MySQLCluster:
+{{- end }}
+
+kubectl apply -f https://github.com/radondb/radondb-mysql-kubernetes/releases/latest/download/mysql_v1alpha1_mysqlcluster.yaml
+
+Create Users:
+
+kubectl apply -f https://github.com/radondb/radondb-mysql-kubernetes/releases/latest/download/mysql_v1alpha1_mysqluser.yaml
+
+{{- if .Values.mysqlcluster.install }}
+
+> Connect to the database:
+{{- else }}
+
+Connect to the database:
+{{- end }}
+
+kubectl exec -it svc/sample-leader -c mysql -- mysql -usuper_usr -pRadonDB@123
+
+Change password:
+
+kubectl patch secret sample-user-password --patch="{\"data\": { \"super_usr\": \"$(echo -n <yourpass> |base64 -w0)\" }}" -oyaml
+
+Github: https://github.com/radondb/radondb-mysql-kubernetes

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -5,6 +5,9 @@
 replicaCount: 1
 installCRDS: true
 
+mysqlcluster:
+  install: false
+  version: v2.2.1
 ## Specify an imagePullPolicy (Required)
 ## It's recommended to change this to 'Always' if the image tag is 'latest'
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images


### PR DESCRIPTION
### What type of PR is this?

/enhancement


### Which issue(s) this PR fixes?

Fixes #516

### What this PR does?

Summary:

add a subchart `mysqlcluster`

uses:
```
helm install demo charts/mysql-operator --set manager.tag=v2.2.0-beta.1 --set mysqlcluster.install=true --set mysqlcluster.operatorVersion=v2.2.0-beta.1
```
### Special notes for your reviewer?

next:

- [x] tls
- [ ] image prefix
- [ ] backup