### PR TITLE
mysqlcluster: when image set error, use replica 0 to rescure it #531

### DIFF
--- a/mysqlcluster/syncer/statefulset.go
+++ b/mysqlcluster/syncer/statefulset.go
@@ -497,6 +497,9 @@ func (s *StatefulSetSyncer) applyNWait(ctx context.Context, pod *corev1.Pod) err
 			if err := s.cli.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod); err != nil {
 				return false, nil
 			}
+			if *s.Spec.Replicas == 0 { // If replicas is 0, don't retry.
+				return true, nil
+			}
 			if pod.DeletionTimestamp != nil {
 				return false, nil
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed #xxx
2. *: what's changed #xxx

-->

### What type of PR is this?

<!--
Add one of the following types:
/bug
/documentation
/cleanup
/enhancement
-->
/bug
### Which issue(s) this PR fixes?

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #531

### What this PR does?

Summary:
1. when set images error, it cannot make statefuset work correct until 2 hours timeout.
2. You could set replica 0, then set image to correct.
### Special notes for your reviewer?
