### PR TITLE
*: Support to configure grant option and SSL when creating users.

### DIFF
--- a/api/v1alpha1/mysqluser_types.go
+++ b/api/v1alpha1/mysqluser_types.go
@@ -142,6 +142,15 @@ type MySQLUserCondition struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:subresource:finalizers
+// +kubebuilder:printcolumn:name="UserName",type="string",JSONPath=".spec.user",description="The name of the MySQL user"
+// +kubebuilder:printcolumn:name="SuperUser",type="boolean",JSONPath=".spec.withGrantOption",description="Whether the user can grant other users"
+// +kubebuilder:printcolumn:name="Hosts",type="string",JSONPath=".spec.hosts",description="The hosts that the user is allowed to connect from"
+// +kubebuilder:printcolumn:name="TLSType",type="string",JSONPath=".spec.tlsOptions.type",description="TLS type of user"
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.userOwner.clusterName",description="The cluster of the user"
+// +kubebuilder:printcolumn:name="NameSpace",type="string",JSONPath=".spec.userOwner.nameSpace",description="The namespace of the user"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="The availability of the user"
+// +kubebuilder:printcolumn:name="SecretName",type="string",priority=1,JSONPath=".spec.secretSelector.secretName",description="The name of the secret object"
+// +kubebuilder:printcolumn:name="SecretKey",type="string",priority=1,JSONPath=".spec.secretSelector.secretKey",description="The key of the secret object"
 // MysqlUser is the Schema for the users API.
 type MysqlUser struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/mysqluser_types.go
+++ b/api/v1alpha1/mysqluser_types.go
@@ -51,6 +51,11 @@ type UserSpec struct {
 	// Permissions is the list of roles that user has in the specified database.
 	// +optional
 	Permissions []UserPermission `json:"permissions,omitempty"`
+
+	// WithGrantOption is the flag to indicate whether the user has grant option.
+	// +optional
+	// +kubebuilder:default:=false
+	WithGrantOption bool `json:"withGrantOption,omitempty"`
 }
 
 type UserOwner struct {

--- a/api/v1alpha1/mysqluser_types.go
+++ b/api/v1alpha1/mysqluser_types.go
@@ -56,6 +56,12 @@ type UserSpec struct {
 	// +optional
 	// +kubebuilder:default:=false
 	WithGrantOption bool `json:"withGrantOption,omitempty"`
+
+	// TLSOptions contains the TLS parameter of the MySQL user.
+	// Enabling SSL/TLS will encrypt the data being sent to and from the database.
+	// https://dev.mysql.com/doc/refman/5.7/en/create-user.html
+	// +kubebuilder:default:={type: "NONE"}
+	TLSOptions TLSOptions `json:"tlsOptions,omitempty"`
 }
 
 type UserOwner struct {
@@ -88,6 +94,15 @@ type UserPermission struct {
 	// Optional parameters can refer to: https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html.
 	// +kubebuilder:validation:MinItems=1
 	Privileges []string `json:"privileges,omitempty"`
+}
+
+type TLSOptions struct {
+	// TLS options for the client certificates
+	// +kubebuilder:default:=NONE
+	// +kubebuilder:validation:Enum=NONE;SSL;X509;
+	Type string `json:"type,omitempty"`
+
+	// TODO: support Issuer, Subject and Cipher.
 }
 
 // UserStatus defines the observed state of MysqlUser.

--- a/charts/mysql-operator/crds/mysql.radondb.com_mysqlusers.yaml
+++ b/charts/mysql-operator/crds/mysql.radondb.com_mysqlusers.yaml
@@ -95,6 +95,11 @@ spec:
                     description: NameSpace is the nameSpace of cluster.
                     type: string
                 type: object
+              withGrantOption:
+                default: false
+                description: WithGrantOption is the flag to indicate whether the user
+                  has grant option.
+                type: boolean
             type: object
           status:
             description: UserStatus defines the observed state of MysqlUser.

--- a/charts/mysql-operator/crds/mysql.radondb.com_mysqlusers.yaml
+++ b/charts/mysql-operator/crds/mysql.radondb.com_mysqlusers.yaml
@@ -16,7 +16,46 @@ spec:
     singular: mysqluser
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The name of the MySQL user
+      jsonPath: .spec.user
+      name: UserName
+      type: string
+    - description: Whether the user can grant other users
+      jsonPath: .spec.withGrantOption
+      name: SuperUser
+      type: boolean
+    - description: The hosts that the user is allowed to connect from
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: TLS type of user
+      jsonPath: .spec.tlsOptions.type
+      name: TLSType
+      type: string
+    - description: The cluster of the user
+      jsonPath: .spec.userOwner.clusterName
+      name: Cluster
+      type: string
+    - description: The namespace of the user
+      jsonPath: .spec.userOwner.nameSpace
+      name: NameSpace
+      type: string
+    - description: The availability of the user
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Available
+      type: string
+    - description: The name of the secret object
+      jsonPath: .spec.secretSelector.secretName
+      name: SecretName
+      priority: 1
+      type: string
+    - description: The key of the secret object
+      jsonPath: .spec.secretSelector.secretKey
+      name: SecretKey
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MysqlUser is the Schema for the users API.

--- a/charts/mysql-operator/crds/mysql.radondb.com_mysqlusers.yaml
+++ b/charts/mysql-operator/crds/mysql.radondb.com_mysqlusers.yaml
@@ -79,6 +79,22 @@ spec:
                     description: SecretName is the name of secret object.
                     type: string
                 type: object
+              tlsOptions:
+                default:
+                  type: NONE
+                description: TLSOptions contains the TLS parameter of the MySQL user.
+                  Enabling SSL/TLS will encrypt the data being sent to and from the
+                  database. https://dev.mysql.com/doc/refman/5.7/en/create-user.html
+                properties:
+                  type:
+                    default: NONE
+                    description: TLS options for the client certificates
+                    enum:
+                    - NONE
+                    - SSL
+                    - X509
+                    type: string
+                type: object
               user:
                 description: Username is the name of user to be operated. This field
                   should be immutable.

--- a/config/crd/bases/mysql.radondb.com_mysqlusers.yaml
+++ b/config/crd/bases/mysql.radondb.com_mysqlusers.yaml
@@ -95,6 +95,11 @@ spec:
                     description: NameSpace is the nameSpace of cluster.
                     type: string
                 type: object
+              withGrantOption:
+                default: false
+                description: WithGrantOption is the flag to indicate whether the user
+                  has grant option.
+                type: boolean
             type: object
           status:
             description: UserStatus defines the observed state of MysqlUser.

--- a/config/crd/bases/mysql.radondb.com_mysqlusers.yaml
+++ b/config/crd/bases/mysql.radondb.com_mysqlusers.yaml
@@ -16,7 +16,46 @@ spec:
     singular: mysqluser
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The name of the MySQL user
+      jsonPath: .spec.user
+      name: UserName
+      type: string
+    - description: Whether the user can grant other users
+      jsonPath: .spec.withGrantOption
+      name: SuperUser
+      type: boolean
+    - description: The hosts that the user is allowed to connect from
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: TLS type of user
+      jsonPath: .spec.tlsOptions.type
+      name: TLSType
+      type: string
+    - description: The cluster of the user
+      jsonPath: .spec.userOwner.clusterName
+      name: Cluster
+      type: string
+    - description: The namespace of the user
+      jsonPath: .spec.userOwner.nameSpace
+      name: NameSpace
+      type: string
+    - description: The availability of the user
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Available
+      type: string
+    - description: The name of the secret object
+      jsonPath: .spec.secretSelector.secretName
+      name: SecretName
+      priority: 1
+      type: string
+    - description: The key of the secret object
+      jsonPath: .spec.secretSelector.secretKey
+      name: SecretKey
+      priority: 1
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MysqlUser is the Schema for the users API.

--- a/config/crd/bases/mysql.radondb.com_mysqlusers.yaml
+++ b/config/crd/bases/mysql.radondb.com_mysqlusers.yaml
@@ -79,6 +79,22 @@ spec:
                     description: SecretName is the name of secret object.
                     type: string
                 type: object
+              tlsOptions:
+                default:
+                  type: NONE
+                description: TLSOptions contains the TLS parameter of the MySQL user.
+                  Enabling SSL/TLS will encrypt the data being sent to and from the
+                  database. https://dev.mysql.com/doc/refman/5.7/en/create-user.html
+                properties:
+                  type:
+                    default: NONE
+                    description: TLS options for the client certificates
+                    enum:
+                    - NONE
+                    - SSL
+                    - X509
+                    type: string
+                type: object
               user:
                 description: Username is the name of user to be operated. This field
                   should be immutable.

--- a/config/samples/mysql_v1alpha1_mysqluser.yaml
+++ b/config/samples/mysql_v1alpha1_mysqluser.yaml
@@ -6,6 +6,9 @@ spec:
   ## User to operate.
   user: sample_user
   withGrantOption: false
+  tlsOptions:
+    ## NONE/SSL/X509
+    type: NONE
   hosts: 
     - "%"
   permissions:

--- a/config/samples/mysql_v1alpha1_mysqluser.yaml
+++ b/config/samples/mysql_v1alpha1_mysqluser.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   ## User to operate.
   user: sample_user
+  withGrantOption: false
   hosts: 
     - "%"
   permissions:

--- a/controllers/mysqluser_controller.go
+++ b/controllers/mysqluser_controller.go
@@ -183,8 +183,7 @@ func (r *MysqlUserReconciler) reconcileUserInDB(ctx context.Context, mysqlUser *
 
 	// Create/Update user in database.
 	userLog.Info("creating mysql user", "key", mysqlUser.GetKey(), "username", mysqlUser.Spec.User, "cluster", mysqlUser.GetClusterKey())
-	if err := internal.CreateUserIfNotExists(sqlRunner, mysqlUser.Spec.User, password, mysqlUser.Spec.Hosts,
-		mysqlUser.Spec.Permissions); err != nil {
+	if err := internal.CreateUserIfNotExists(sqlRunner, mysqlUser.Unwrap(), password); err != nil {
 		return err
 	}
 

--- a/internal/sql_runner.go
+++ b/internal/sql_runner.go
@@ -334,9 +334,10 @@ func columnValue(scanArgs []interface{}, slaveCols []string, colName string) str
 }
 
 // CreateUserIfNotExists creates a user if it doesn't already exist and it gives it the specified permissions.
-func CreateUserIfNotExists(
-	sqlRunner SQLRunner, user, pass string, hosts []string, permissions []apiv1alpha1.UserPermission,
-) error {
+func CreateUserIfNotExists(sqlRunner SQLRunner, user *apiv1alpha1.MysqlUser, pass string) error {
+	userName := user.Spec.User
+	hosts := user.Spec.Hosts
+	permissions := user.Spec.Permissions
 
 	// Throw error if there are no allowed hosts.
 	if len(hosts) == 0 {
@@ -344,12 +345,12 @@ func CreateUserIfNotExists(
 	}
 
 	queries := []Query{
-		getCreateUserQuery(user, pass, hosts),
+		getCreateUserQuery(userName, pass, hosts),
 		// todo: getAlterUserQuery.
 	}
 
 	if len(permissions) > 0 {
-		queries = append(queries, permissionsToQuery(permissions, user, hosts))
+		queries = append(queries, permissionsToQuery(permissions, userName, hosts, user.Spec.WithGrantOption))
 	}
 
 	query := BuildAtomicQuery(queries...)
@@ -397,7 +398,7 @@ func DropUser(sqlRunner SQLRunner, user, host string) error {
 	return nil
 }
 
-func permissionsToQuery(permissions []apiv1alpha1.UserPermission, user string, allowedHosts []string) Query {
+func permissionsToQuery(permissions []apiv1alpha1.UserPermission, user string, allowedHosts []string, withGrant bool) Query {
 	permQueries := []Query{}
 
 	for _, perm := range permissions {
@@ -416,6 +417,9 @@ func permissionsToQuery(permissions []apiv1alpha1.UserPermission, user string, a
 			idsTmpl, idsArgs := getUsersIdentification(user, nil, allowedHosts)
 
 			query := "GRANT " + strings.Join(escPerms, ", ") + " ON " + schemaTable + " TO" + idsTmpl
+			if withGrant {
+				query += " WITH GRANT OPTION"
+			}
 			args = append(args, idsArgs...)
 
 			permQueries = append(permQueries, NewQuery(query, args...))

--- a/internal/sql_runner.go
+++ b/internal/sql_runner.go
@@ -345,7 +345,7 @@ func CreateUserIfNotExists(sqlRunner SQLRunner, user *apiv1alpha1.MysqlUser, pas
 	}
 
 	queries := []Query{
-		getCreateUserQuery(userName, pass, hosts),
+		getCreateUserQuery(userName, pass, hosts, user.Spec.TLSOptions),
 		// todo: getAlterUserQuery.
 	}
 
@@ -362,10 +362,15 @@ func CreateUserIfNotExists(sqlRunner SQLRunner, user *apiv1alpha1.MysqlUser, pas
 	return nil
 }
 
-func getCreateUserQuery(user, pwd string, allowedHosts []string) Query {
+func getCreateUserQuery(user, pwd string, allowedHosts []string, tlsOption apiv1alpha1.TLSOptions) Query {
 	idsTmpl, idsArgs := getUsersIdentification(user, &pwd, allowedHosts)
+	idsTmpl += getUserTLSRequire(tlsOption)
 
 	return NewQuery(fmt.Sprintf("CREATE USER IF NOT EXISTS%s", idsTmpl), idsArgs...)
+}
+
+func getUserTLSRequire(tlsOption apiv1alpha1.TLSOptions) string {
+	return fmt.Sprintf(" REQUIRE %s", tlsOption.Type)
 }
 
 func getUsersIdentification(user string, pwd *string, allowedHosts []string) (ids string, args []interface{}) {


### PR DESCRIPTION
### What type of PR is this?


/bug
/enhancement


### Which issue(s) this PR fixes?

Fixes #573 #577

### What this PR does?


Summary:

- add options `WithGrantOption`
- add options `TLSOptions`
- support create user with grant
- support create user with ssl options
- add print columns

```
 » kubectl get mysqluser                                                                                                  
NAME          USERNAME      SUPERUSER   HOSTS   TLSTYPE   CLUSTER   NAMESPACE   AVAILABLE
normal-user   normal_user   false       ["%"]   NONE      sample    default     True
super-user    super_user    true        ["%"]   NONE      sample    default     True

 » kubectl get mysqluser -o wide                                                                                         
NAME          USERNAME      SUPERUSER   HOSTS   TLSTYPE   CLUSTER   NAMESPACE   AVAILABLE   SECRETNAME             SECRETKEY
normal-user   normal_user   false       ["%"]   NONE      sample    default     True        sample-user-password   normalUser
super-user    super_user    true        ["%"]   NONE      sample    default     True        sample-user-password   superUser
```

### Special notes for your reviewer?
