### PR TITLE
ci: add more assets in release 

### DIFF
--- a/.github/workflows/publish_charts.yml
+++ b/.github/workflows/publish_charts.yml
@@ -6,6 +6,9 @@ on:
       version:
         required: true
         type: string
+      upload_url:
+        required: true 
+        type: string
 
 jobs:
   build:
@@ -22,9 +25,11 @@ jobs:
           version: v3.6.3
 
       - name: Modify chart version
+        id: chart_version
         run: |
           input=${{ inputs.version }}
           chart_version=${input#*v}
+          echo "::set-output name=asset_name::mysql-operator-$chart_version.tgz"
           sed -i "/^version:*/cversion: $chart_version" ./charts/mysql-operator/Chart.yaml
 
       - name: Modify appVersion
@@ -38,10 +43,20 @@ jobs:
       - name: Packaging the chart
         run: helm package ./charts/mysql-operator/
 
+      - name: Upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ inputs.upload_url }} 
+          asset_path: ./${{ steps.chart_version.outputs.asset_name }}
+          asset_name: ${{ steps.chart_version.outputs.asset_name }}
+          asset_content_type: application/gzip
+
       - uses: actions/upload-artifact@v2
         with:
           name: mysql-operator-chart
-          path: ./mysql-operator-*.tgz
+          path: ./${{ steps.chart_version.outputs.asset_name }}
           retention-days: 1
 
   publish:

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build_operator:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/build_operator_image.yml@main
+    uses: ./.github/workflows/build_operator_image.yml
     if: ${{ github.event.inputs.build_operator == 'true' }}
     with:
       image_tag: ${{ github.event.inputs.tag }}
@@ -34,7 +34,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   build_sidecar:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/build_sidecar_image.yml@main
+    uses: ./.github/workflows/build_sidecar_image.yml
     if: ${{ github.event.inputs.build_sidecar == 'true' }}
     with:
       image_tag: ${{ github.event.inputs.tag }} 
@@ -43,7 +43,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   build_xenon:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/build_xenon_image.yml@main
+    uses: ./.github/workflows/build_xenon_image.yml
     if: ${{ github.event.inputs.build_xenon == 'true' }}
     with:
       image_tag: ${{ github.event.inputs.tag }} 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -10,14 +10,14 @@ on:
 
 jobs: 
   update_release_draft:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/release_drafter.yml@main
+    uses: ./.github/workflows/release_drafter.yml
     with:
       version: ${{ github.event.inputs.version }}
     secrets:
       git_token: ${{ secrets.GITHUB_TOKEN }}
   
   build_operator:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/build_operator_image.yml@main
+    uses: ./.github/workflows/build_operator_image.yml
     needs: update_release_draft
     with:
       image_tag: ${{ needs.update_release_draft.outputs.version }}
@@ -26,7 +26,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   build_sidecar:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/build_sidecar_image.yml@main
+    uses: ./.github/workflows/build_sidecar_image.yml
     needs: update_release_draft
     with:
       image_tag: ${{ needs.update_release_draft.outputs.version }} 
@@ -35,7 +35,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   publish_chart:
-    uses: radondb/radondb-mysql-kubernetes/.github/workflows/publish_charts.yml@main
+    uses: ./.github/workflows/publish_charts.yml
     if: ${{ github.event.inputs.version == '' }}
     needs: update_release_draft
     with:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -40,3 +40,4 @@ jobs:
     needs: update_release_draft
     with:
       version: ${{ needs.update_release_draft.outputs.version }}
+      upload_url: ${{ needs.update_release_draft.outputs.upload_url }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -34,6 +34,15 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  build_xenon:
+    uses: ./.github/workflows/build_xenon_image.yml
+    needs: update_release_draft
+    with:
+      image_tag: ${{ needs.update_release_draft.outputs.version }} 
+    secrets: 
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
   publish_chart:
     uses: ./.github/workflows/publish_charts.yml
     if: ${{ github.event.inputs.version == '' }}

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -15,11 +15,16 @@ on:
       version:
         description: "The release version"
         value: ${{ jobs.update_release_draft.outputs.version }}
+      upload_url:
+        description: "The URL of uploading assets"
+        value: ${{ jobs.update_release_draft.outputs.upload_url }}
+
 jobs: 
     update_release_draft:
       runs-on: ubuntu-latest
       outputs:
         version: ${{ steps.draft.outputs.tag_name }}
+        upload_url: ${{ steps.draft.outputs.upload_url }}
       steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -57,4 +62,14 @@ jobs:
           upload_url: ${{ steps.draft.outputs.upload_url }} 
           asset_path: ./config/samples/mysql_v1alpha1_mysqlcluster_mysql8.yaml
           asset_name: mysql_v1alpha1_mysqlcluster_mysql8.yaml
+          asset_content_type: application/x-yaml
+
+      - name: Upload mysqluser sample yaml
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.git_token }}
+        with:
+          upload_url: ${{ steps.draft.outputs.upload_url }} 
+          asset_path: ./config/samples/mysql_v1alpha1_mysqluser.yaml
+          asset_name: mysql_v1alpha1_mysqluser.yaml
           asset_content_type: application/x-yaml


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

Fixes #616

### What this PR does?

Summary:

- add more assets in release 
  - sample of the mysqluser
  - package of the operator chart
- use the relative path
- build xenon when publish release


### Special notes for your reviewer?

https://github.com/runkecheng/radondb-mysql-kubernetes/releases/tag/untagged-0ae7969c3d9c5f785fc2