### PR TITLE
*: support MySQL configuration template

### DIFF
--- a/api/v1alpha1/mysqlcluster_types.go
+++ b/api/v1alpha1/mysqlcluster_types.go
@@ -145,9 +145,23 @@ type MysqlOpts struct {
 	// +kubebuilder:default:=false
 	InitTokuDB bool `json:"initTokuDB,omitempty"`
 
+	// MysqlConfTemplate is the configmap name of the template for mysql config.
+	// The configmap should contain the keys `mysql.cnf` and `plugin.cnf` at least, key `init.sql` is optional.
+	// If empty, operator will generate a default template named <spec.metadata.name>-mysql.
+	// +optional
+	MysqlConfTemplate string `json:"mysqlConfTemplate,omitempty"`
+
 	// A map[string]string that will be passed to my.cnf file.
+	// The key/value pairs is persisted in the configmap.
+	// Delete key is not valid, it is recommended to edit the configmap directly.
 	// +optional
 	MysqlConf MysqlConf `json:"mysqlConf,omitempty"`
+
+	// A map[string]string that will be passed to plugin.cnf file.
+	// The key/value pairs is persisted in the configmap.
+	// Delete key is not valid, it is recommended to edit the configmap directly.
+	// +optional
+	PluginConf MysqlConf `json:"pluginConf,omitempty"`
 
 	// The compute resource requirements.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -341,6 +341,13 @@ func (in *MysqlOpts) DeepCopyInto(out *MysqlOpts) {
 			(*out)[key] = val
 		}
 	}
+	if in.PluginConf != nil {
+		in, out := &in.PluginConf, &out.PluginConf
+		*out = make(MysqlConf, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 }
 

--- a/charts/mysql-operator/crds/mysql.radondb.com_mysqlclusters.yaml
+++ b/charts/mysql-operator/crds/mysql.radondb.com_mysqlclusters.yaml
@@ -160,8 +160,15 @@ spec:
                     additionalProperties:
                       type: string
                     description: A map[string]string that will be passed to my.cnf
-                      file.
+                      file. The key/value pairs is persisted in the configmap. Delete
+                      key is not valid, it is recommended to edit the configmap directly.
                     type: object
+                  mysqlConfTemplate:
+                    description: MysqlConfTemplate is the configmap name of the template
+                      for mysql config. The configmap should contain the keys `mysql.cnf`
+                      and `plugin.cnf` at least, key `init.sql` is optional. If empty,
+                      operator will generate a default template named <spec.metadata.name>-mysql.
+                    type: string
                   password:
                     default: RadonDB@123
                     description: 'Password for the new user, must be 8~32 characters
@@ -170,6 +177,13 @@ spec:
                       supported: @#$%^&*_+-=.'
                     pattern: ^[A-Za-z0-9@#$%^&*_+\-=]{8,32}$
                     type: string
+                  pluginConf:
+                    additionalProperties:
+                      type: string
+                    description: A map[string]string that will be passed to plugin.cnf
+                      file. The key/value pairs is persisted in the configmap. Delete
+                      key is not valid, it is recommended to edit the configmap directly.
+                    type: object
                   resources:
                     default:
                       limits:

--- a/charts/mysql-operator/templates/mysql57_template.yaml
+++ b/charts/mysql-operator/templates/mysql57_template.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: radondb-mysql57-template
+  namespace: {{ default .Release.Namespace .Values.mysqlConfTemplate.namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "mysql-version": "5.7"
+data:
+  my.cnf: |
+    [mysqld]
+    expire-logs-days                = 7
+    master_info_repository          = TABLE
+    query-cache-size                = 0
+    query-cache-type                = 0
+    relay_log_info_repository       = TABLE
+    slave_rows_search_algorithms    = INDEX_SCAN,HASH_SCAN
+    sql-mode                        = STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
+    binlog_format                   = row
+    default-time-zone               = +08:00
+    enforce-gtid-consistency        = ON
+    gtid-mode                       = ON
+    innodb_open_files               = 655360
+    log-bin                         = /var/lib/mysql/mysql-bin
+    log-timestamps                  = SYSTEM
+    open_files_limit                = 655360
+    read_only                       = ON
+    relay_log                       = /var/lib/mysql/mysql-relay-bin
+    relay_log_index                 = /var/lib/mysql/mysql-relay-bin.index
+    slave_parallel_type             = LOGICAL_CLOCK
+    slow_query_log                  = 1
+    slow_query_log_file             = /var/log/mysql/mysql-slow.log
+    tmp_table_size                  = 32M
+    tmpdir                          = /var/lib/mysql
+    autocommit                      = 1
+    binlog_cache_size               = 32768
+    binlog_stmt_cache_size          = 32768
+    character_set_server            = utf8mb4
+    event_scheduler                 = OFF
+    explicit_defaults_for_timestamp = 0
+    group_concat_max_len            = 1024
+    innodb_adaptive_hash_index      = 0
+    innodb_print_all_deadlocks      = 0
+    interactive_timeout             = 3600
+    key_buffer_size                 = 33554432
+    log_bin_trust_function_creators = 1
+    long_query_time                 = 3
+    max_allowed_packet              = 1073741824
+    max_connect_errors              = 655360
+    max_connections                 = 1024
+    sync_master_info                = 1000
+    sync_relay_log                  = 1000
+    sync_relay_log_info             = 1000
+    table_open_cache                = 2000
+    thread_cache_size               = 128
+    transaction-isolation           = READ-COMMITTED
+    wait_timeout                    = 3600
+    back_log                        = 2048
+    default-storage-engine          = InnoDB
+    ft_min_word_len                 = 4
+    innodb_autoinc_lock_mode        = 2
+    innodb_flush_method             = O_DIRECT
+    innodb_ft_max_token_size        = 84
+    innodb_ft_min_token_size        = 3
+    innodb_log_buffer_size          = 16777216
+    innodb_log_files_in_group       = 2
+    lower_case_table_names          = 0
+    performance_schema              = 1
+    slave_parallel_workers          = 8
+    slave_pending_jobs_size_max     = 1073741824
+    sql_mode                        = STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION
+    federated
+    skip-host-cache
+    skip-name-resolve
+    core-file
+    skip-slave-start
+    log-slave-updates
+    !includedir /etc/mysql/conf.d 
+  plugin.cnf: |
+    [mysqld]
+    audit_log_buffer_size                           = 16M
+    audit_log_exclude_accounts                      = "root@localhost,root@127.0.0.1,radondb_repl@%,radondb_metrics@%"
+    audit_log_file                                  = /var/log/mysql/mysql-audit.log
+    audit_log_format                                = OLD
+    audit_log_policy                                = NONE
+    audit_log_rotate_on_size                        = 104857600
+    audit_log_rotations                             = 6
+    connection_control_failed_connections_threshold = 3
+    connection_control_max_connection_delay         = 2147483647
+    connection_control_min_connection_delay         = 1000
+    plugin-load                                     = "semisync_master.so;semisync_slave.so;audit_log.so;connection_control.so"
+    rpl_semi_sync_master_enabled                    = OFF
+    rpl_semi_sync_master_timeout                    = 1000000000000000000
+    rpl_semi_sync_master_wait_no_slave              = ON
+    rpl_semi_sync_slave_enabled                     = ON
+  init.sql: |

--- a/charts/mysql-operator/templates/mysql80_template.yaml
+++ b/charts/mysql-operator/templates/mysql80_template.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: radondb-mysql80-template
+  namespace: {{ default .Release.Namespace .Values.mysqlConfTemplate.namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "mysql-version": "8.0"
+data:
+  my.cnf: |
+    [mysqld]
+    expire-logs-days                = 7
+    master_info_repository          = TABLE
+    query-cache-size                = 0
+    query-cache-type                = 0
+    relay_log_info_repository       = TABLE
+    slave_rows_search_algorithms    = INDEX_SCAN,HASH_SCAN
+    sql-mode                        = STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY
+    binlog_format                   = row
+    default-time-zone               = +08:00
+    enforce-gtid-consistency        = ON
+    gtid-mode                       = ON
+    innodb_open_files               = 655360
+    log-bin                         = /var/lib/mysql/mysql-bin
+    log-timestamps                  = SYSTEM
+    open_files_limit                = 655360
+    read_only                       = ON
+    relay_log                       = /var/lib/mysql/mysql-relay-bin
+    relay_log_index                 = /var/lib/mysql/mysql-relay-bin.index
+    slave_parallel_type             = LOGICAL_CLOCK
+    slow_query_log                  = 1
+    slow_query_log_file             = /var/log/mysql/mysql-slow.log
+    tmp_table_size                  = 32M
+    tmpdir                          = /var/lib/mysql
+    autocommit                      = 1
+    binlog_cache_size               = 32768
+    binlog_stmt_cache_size          = 32768
+    character_set_server            = utf8mb4
+    event_scheduler                 = OFF
+    explicit_defaults_for_timestamp = 0
+    group_concat_max_len            = 1024
+    innodb_adaptive_hash_index      = 0
+    innodb_print_all_deadlocks      = 0
+    interactive_timeout             = 3600
+    key_buffer_size                 = 33554432
+    log_bin_trust_function_creators = 1
+    long_query_time                 = 3
+    max_allowed_packet              = 1073741824
+    max_connect_errors              = 655360
+    max_connections                 = 1024
+    sync_master_info                = 1000
+    sync_relay_log                  = 1000
+    sync_relay_log_info             = 1000
+    table_open_cache                = 2000
+    thread_cache_size               = 128
+    transaction-isolation           = READ-COMMITTED
+    wait_timeout                    = 3600
+    back_log                        = 2048
+    default-storage-engine          = InnoDB
+    ft_min_word_len                 = 4
+    innodb_autoinc_lock_mode        = 2
+    innodb_flush_method             = O_DIRECT
+    innodb_ft_max_token_size        = 84
+    innodb_ft_min_token_size        = 3
+    innodb_log_buffer_size          = 16777216
+    innodb_log_files_in_group       = 2
+    lower_case_table_names          = 0
+    performance_schema              = 1
+    slave_parallel_workers          = 8
+    slave_pending_jobs_size_max     = 1073741824
+    binlog_expire_logs_seconds      = 604800
+    default-authentication-plugin   = mysql_native_password
+    federated
+    skip-host-cache
+    skip-name-resolve
+    core-file
+    skip-slave-start
+    log-slave-updates
+    !includedir /etc/mysql/conf.d 
+  plugin.cnf: |
+    [mysqld]
+    plugin-load                                     = "semisync_master.so;semisync_slave.so;audit_log.so;connection_control.so"
+    audit_log_buffer_size                           = 16M
+    audit_log_exclude_accounts                      = "root@localhost,root@127.0.0.1,radondb_repl@%,radondb_metrics@%"
+    audit_log_file                                  = /var/log/mysql/mysql-audit.log
+    audit_log_format                                = OLD
+    audit_log_policy                                = NONE
+    audit_log_rotate_on_size                        = 104857600
+    audit_log_rotations                             = 6
+    connection_control_failed_connections_threshold = 3
+    connection_control_max_connection_delay         = 2147483647
+    connection_control_min_connection_delay         = 1000
+    rpl_semi_sync_master_enabled                    = OFF
+    rpl_semi_sync_master_timeout                    = 1000000000000000000
+    rpl_semi_sync_master_wait_no_slave              = ON
+    rpl_semi_sync_slave_enabled                     = ON
+  init.sql: |

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -38,6 +38,9 @@ manager:
     #   cpu: 100m
     #   memory: 20Mi
 
+mysqlConfTemplate:
+  namespace: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/config/crd/bases/mysql.radondb.com_mysqlclusters.yaml
+++ b/config/crd/bases/mysql.radondb.com_mysqlclusters.yaml
@@ -160,8 +160,15 @@ spec:
                     additionalProperties:
                       type: string
                     description: A map[string]string that will be passed to my.cnf
-                      file.
+                      file. The key/value pairs is persisted in the configmap. Delete
+                      key is not valid, it is recommended to edit the configmap directly.
                     type: object
+                  mysqlConfTemplate:
+                    description: MysqlConfTemplate is the configmap name of the template
+                      for mysql config. The configmap should contain the keys `mysql.cnf`
+                      and `plugin.cnf` at least, key `init.sql` is optional. If empty,
+                      operator will generate a default template named <spec.metadata.name>-mysql.
+                    type: string
                   password:
                     default: RadonDB@123
                     description: 'Password for the new user, must be 8~32 characters
@@ -170,6 +177,13 @@ spec:
                       supported: @#$%^&*_+-=.'
                     pattern: ^[A-Za-z0-9@#$%^&*_+\-=]{8,32}$
                     type: string
+                  pluginConf:
+                    additionalProperties:
+                      type: string
+                    description: A map[string]string that will be passed to plugin.cnf
+                      file. The key/value pairs is persisted in the configmap. Delete
+                      key is not valid, it is recommended to edit the configmap directly.
+                    type: object
                   resources:
                     default:
                       limits:

--- a/controllers/mysqlcluster_controller.go
+++ b/controllers/mysqlcluster_controller.go
@@ -115,7 +115,7 @@ func (r *MysqlClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, r.deleteAllBackup(ctx, req, instance.Unwrap())
 	}
 	mysqlCMSyncer := clustersyncer.NewMysqlCMSyncer(r.Client, instance)
-	if err = syncer.Sync(ctx, mysqlCMSyncer, r.Recorder); err != nil {
+	if err = clustersyncer.Sync(ctx, mysqlCMSyncer, r.Recorder); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/mysqlcluster/mysqlcluster.go
+++ b/mysqlcluster/mysqlcluster.go
@@ -329,7 +329,7 @@ func (c *MysqlCluster) EnsureVolumeClaimTemplates(schema *runtime.Scheme) ([]cor
 // GetNameForResource returns the name of a resource from above
 func (c *MysqlCluster) GetNameForResource(name utils.ResourceName) string {
 	switch name {
-	case utils.StatefulSet, utils.ConfigMap, utils.HeadlessSVC, utils.PodDisruptionBudget:
+	case utils.StatefulSet, utils.HeadlessSVC, utils.PodDisruptionBudget:
 		return fmt.Sprintf("%s-mysql", c.Name)
 	case utils.LeaderService:
 		return fmt.Sprintf("%s-leader", c.Name)
@@ -341,6 +341,11 @@ func (c *MysqlCluster) GetNameForResource(name utils.ResourceName) string {
 		return fmt.Sprintf("%s-secret", c.Name)
 	case utils.XenonMetaData:
 		return fmt.Sprintf("%s-xenon", c.Name)
+	case utils.ConfigMap:
+		if template := c.Spec.MysqlOpts.MysqlConfTemplate; template != "" {
+			return template
+		}
+		return fmt.Sprintf("%s-mysql", c.Name)
 	default:
 		return c.Name
 	}

--- a/mysqlcluster/syncer/mysql_cm.go
+++ b/mysqlcluster/syncer/mysql_cm.go
@@ -18,52 +18,221 @@ package syncer
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/go-ini/ini"
-	"github.com/presslabs/controller-util/pkg/syncer"
-
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/radondb/radondb-mysql-kubernetes/mysqlcluster"
 	"github.com/radondb/radondb-mysql-kubernetes/utils"
 )
 
+type mysqlCMSyncer struct {
+	*mysqlcluster.MysqlCluster
+
+	cli client.Client
+
+	cm *corev1.ConfigMap
+
+	log logr.Logger
+}
+
 // NewMysqlCMSyncer returns mysql configmap syncer.
-func NewMysqlCMSyncer(cli client.Client, c *mysqlcluster.MysqlCluster) syncer.Interface {
-	cm := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
+func NewMysqlCMSyncer(cli client.Client, c *mysqlcluster.MysqlCluster) *mysqlCMSyncer {
+	return &mysqlCMSyncer{
+		MysqlCluster: c,
+		cli:          cli,
+		cm: &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      c.GetNameForResource(utils.ConfigMap),
+				Namespace: c.Namespace,
+				Labels:    c.GetLabels(),
+			},
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.GetNameForResource(utils.ConfigMap),
-			Namespace: c.Namespace,
-			Labels:    c.GetLabels(),
-		},
+		log: logf.Log.WithName("MySQLCMSyncer"),
+	}
+}
+
+// Object returns the object for which sync applies.
+func (s *mysqlCMSyncer) Object() interface{} {
+	return s.cm
+}
+
+// Owner returns the object owner or nil if object does not have one.
+func (s *mysqlCMSyncer) ObjectOwner() runtime.Object {
+	return s.MysqlCluster
+}
+
+// Sync persists data into the external store.
+func (s *mysqlCMSyncer) Sync(ctx context.Context) (SyncResult, error) {
+	var err error
+	var kind string
+	result := SyncResult{}
+
+	result.Operation, err = s.createOrUpdate(ctx)
+
+	// Get namespace and name.
+	key := client.ObjectKeyFromObject(s.cm)
+	// Get groupVersionKind.
+	gvk, gvkErr := apiutil.GVKForObject(s.cm, s.cli.Scheme())
+	if gvkErr != nil {
+		kind = fmt.Sprintf("%T", s.cm)
+	} else {
+		kind = gvk.String()
 	}
 
-	return syncer.NewObjectSyncer("ConfigMap", c.Unwrap(), cm, cli, func() error {
-		data, err := buildMysqlConf(c)
+	switch {
+	case errors.Is(err, ErrOwnerDeleted):
+		s.log.Info(string(result.Operation), "key", key, "kind", kind, "error", err)
+		err = nil
+	case errors.Is(err, ErrIgnore):
+		s.log.Info("syncer skipped", "key", key, "kind", kind, "error", err)
+		err = nil
+	case err != nil:
+		result.SetEventData("Warning", basicEventReason(s.Name, err), fmt.Sprintf("%s %s failed syncing: %s", kind, key, err))
+		s.log.Error(err, string(result.Operation), "key", key, "kind", kind)
+	default:
+		result.SetEventData("Normal", basicEventReason(s.Name, err), fmt.Sprintf("%s %s %s successfully", kind, key, result.Operation))
+		s.log.Info(string(result.Operation), "key", key, "kind", kind)
+	}
+	return result, err
+}
+
+func (s *mysqlCMSyncer) createOrUpdate(ctx context.Context) (controllerutil.OperationResult, error) {
+	var err error
+	if err = s.cli.Get(ctx, client.ObjectKeyFromObject(s.cm), s.cm); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return resultNone, err
+		}
+
+		if s.Spec.MysqlOpts.MysqlConfTemplate != "" {
+			return resultNone, fmt.Errorf("template is not exist: %s", s.Spec.MysqlOpts.MysqlConfTemplate)
+		}
+
+		if err = s.generateTemplate(ctx); err != nil {
+			return resultNone, err
+		}
+
+		if err = s.cli.Create(ctx, s.cm); err != nil {
+			return resultNone, err
+		} else {
+			return resultCreated, nil
+		}
+	}
+
+	if err := s.appendConf(); err != nil {
+		return resultNone, err
+	}
+
+	if err := s.setControllerReference(); err != nil {
+		return resultNone, err
+	}
+
+	if err = s.cli.Update(ctx, s.cm); err != nil {
+		return resultNone, err
+	}
+
+	return resultNone, nil
+}
+
+func (s *mysqlCMSyncer) generateTemplate(ctx context.Context) error {
+	if s.Spec.MysqlOpts.MysqlConfTemplate == "" {
+		data, err := buildMysqlConf(s.MysqlCluster)
 		if err != nil {
 			return fmt.Errorf("failed to create mysql configs: %s", err)
 		}
 
-		dataPlugin, err := buildMysqlPluginConf(c)
+		dataPlugin, err := buildMysqlPluginConf(s.MysqlCluster)
 		if err != nil {
 			return fmt.Errorf("failed to create mysql plugin configs: %s", err)
 		}
-		cm.Data = map[string]string{
+		s.cm.Data = map[string]string{
 			"my.cnf":            data,
 			utils.PluginConfigs: dataPlugin,
 		}
-
 		return nil
-	})
+	}
+	return fmt.Errorf("MysqlConfTemplate is empty")
+}
+
+// Notice: The parameters will not be removed from the cm when its removed from the mysqlConf/pluginConf.
+func (s *mysqlCMSyncer) appendConf() error {
+	if err := s.createOrReplaceIniKey("my.cnf", s.Spec.MysqlOpts.MysqlConf); err != nil {
+		return err
+	}
+	if err := s.createOrReplaceIniKey("plugin.cnf", s.Spec.MysqlOpts.PluginConf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *mysqlCMSyncer) setControllerReference() error {
+	if s.MysqlCluster == nil {
+		return fmt.Errorf("owner is nil")
+	}
+	// Set owner reference only if owner resource is not being deleted, otherwise the owner
+	// reference will be reset in case of deleting with cascade=false.
+	if s.Unwrap().GetDeletionTimestamp().IsZero() {
+		if err := controllerutil.SetControllerReference(s.Unwrap(), s.cm, s.cli.Scheme()); err != nil {
+			return err
+		}
+	} else if ctime := s.Unwrap().GetCreationTimestamp(); ctime.IsZero() {
+		// The owner is deleted, don't recreate the resource if does not exist, because gc
+		// will not delete it again because has no owner reference set.
+		return fmt.Errorf("owner is deleted")
+	}
+	return nil
+}
+
+func (s *mysqlCMSyncer) createOrReplaceIniKey(key string, patch map[string]string) error {
+	if len(patch) == 0 {
+		return nil
+	}
+	if f, ok := s.cm.Data[key]; ok {
+		if iniFile, err := ini.LoadSources(ini.LoadOptions{IgnoreInlineComment: true, AllowBooleanKeys: true}, []byte(f)); err != nil {
+			return fmt.Errorf("failed to load %s, err: %s", key, err.Error())
+		} else {
+			sec := iniFile.Section("mysqld")
+			keys := []string{}
+			for k := range patch {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			for _, k := range keys {
+				// TODO: repeatable key, like plugin-load-add
+				if sec.HasKey(k) {
+					sec.Key(k).SetValue(patch[k])
+				} else { // Not in sec.
+					// Add it to sec
+					if _, err := sec.NewKey(k, patch[k]); err != nil {
+						return fmt.Errorf("failed to add key to config section: %s", err)
+					}
+				}
+			}
+			data, err := writeConfigs(iniFile)
+			if err != nil {
+				return fmt.Errorf("failed to write configs: %s", err)
+			}
+			s.cm.Data[key] = data
+		}
+	}
+	return nil
 }
 
 // buildMysqlConf build the mysql config.
@@ -95,24 +264,7 @@ func buildMysqlConf(c *mysqlcluster.MysqlCluster) (string, error) {
 	if len(c.Spec.TlsSecretName) != 0 {
 		addKVConfigsToSection(sec, mysqlSSLConfigs)
 	}
-	keys := []string{}
-	for k := range c.Spec.MysqlOpts.MysqlConf {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, k := range keys {
-		if sec.HasKey(k) {
-			sec.Key(k).SetValue(c.Spec.MysqlOpts.MysqlConf[k])
-		} else { // Not in sec.
-			if _, ok := pluginConfigs[k]; !ok { // Not in pluginconfig.
-				// Add it to sec
-				if _, err := sec.NewKey(k, c.Spec.MysqlOpts.MysqlConf[k]); err != nil {
-					return "", fmt.Errorf("failed to add key to config section: %s", err)
-				}
-			}
-		}
-	}
+	addKVConfigsToSection(sec, c.Spec.MysqlOpts.MysqlConf)
 
 	data, err := writeConfigs(cfg)
 	if err != nil {
@@ -127,13 +279,8 @@ func buildMysqlPluginConf(c *mysqlcluster.MysqlCluster) (string, error) {
 	cfg := ini.Empty(ini.LoadOptions{IgnoreInlineComment: true})
 	sec := cfg.Section("mysqld")
 
-	for k, v := range c.Spec.MysqlOpts.MysqlConf {
-		if _, ok := pluginConfigs[k]; ok {
-			pluginConfigs[k] = v
-		}
-	}
-
 	addKVConfigsToSection(sec, pluginConfigs)
+	addKVConfigsToSection(sec, c.Spec.MysqlOpts.PluginConf)
 	data, err := writeConfigs(cfg)
 	if err != nil {
 		return "", err

--- a/mysqlcluster/syncer/objectSyncer.go
+++ b/mysqlcluster/syncer/objectSyncer.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2022 RadonDB.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-test/deep"
+	"github.com/iancoleman/strcase"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	eventNormal  = "Normal"
+	eventWarning = "Warning"
+
+	resultNone    = controllerutil.OperationResultNone
+	resultCreated = controllerutil.OperationResultCreated
+	resultUpdated = controllerutil.OperationResultUpdated
+)
+
+var (
+	// ErrOwnerDeleted is returned when the object owner is marked for deletion.
+	ErrOwnerDeleted = fmt.Errorf("owner is deleted")
+
+	// ErrIgnore is returned for ignored errors.
+	// Ignored errors are treated by the syncer as successful syncs.
+	ErrIgnore = fmt.Errorf("ignored error")
+)
+
+// Interface represents a syncer. A syncer persists an object
+// (known as subject), into a store (kubernetes apiserver or generic stores)
+// and records kubernetes events.
+type Syncer interface {
+	// Object returns the object for which sync applies.
+	Object() interface{}
+
+	// Owner returns the object owner or nil if object does not have one.
+	ObjectOwner() runtime.Object
+
+	// Sync persists data into the external store.
+	Sync(context.Context) (SyncResult, error)
+}
+
+// SyncResult is a result of an Sync call.
+type SyncResult struct {
+	Operation    controllerutil.OperationResult
+	EventType    string
+	EventReason  string
+	EventMessage string
+}
+
+// SetEventData sets event data on an SyncResult.
+func (r *SyncResult) SetEventData(eventType, reason, message string) {
+	r.EventType = eventType
+	r.EventReason = reason
+	r.EventMessage = message
+}
+
+// ObjectSyncer is a syncer.Interface for syncing kubernetes.Objects only by
+// passing a SyncFn.
+type ObjectSyncer struct {
+	Owner     client.Object
+	Obj       client.Object
+	SyncFn    controllerutil.MutateFn
+	Name      string
+	Client    client.Client
+	ForceSync bool
+
+	previousObject runtime.Object
+}
+
+// NewObjectSyncer creates a new kubernetes.Object syncer for a given object
+// with an owner and persists data using controller-runtime's CreateOrUpdate.
+// The name is used for logging and event emitting purposes and should be an
+// valid go identifier in upper camel case. (eg. MysqlStatefulSet).
+func NewObjectSyncer(name string, owner, obj client.Object, c client.Client, forceSync bool, syncFn controllerutil.MutateFn) Syncer {
+	return &ObjectSyncer{
+		Owner:     owner,
+		Obj:       obj,
+		SyncFn:    syncFn,
+		Name:      name,
+		Client:    c,
+		ForceSync: forceSync,
+	}
+}
+
+// Object returns the ObjectSyncer subject.
+func (s *ObjectSyncer) Object() interface{} {
+	return s.Obj
+}
+
+// ObjectOwner returns the ObjectSyncer owner.
+func (s *ObjectSyncer) ObjectOwner() runtime.Object {
+	return s.Owner
+}
+
+// Sync does the actual syncing and implements the syncer.Inteface Sync method.
+func (s *ObjectSyncer) Sync(ctx context.Context) (SyncResult, error) {
+	var err error
+
+	result := SyncResult{}
+	log := logf.FromContext(ctx, "syncer", s.Name)
+	key := client.ObjectKeyFromObject(s.Obj)
+
+	if s.ForceSync {
+		result.Operation, err = controllerutil.CreateOrUpdate(ctx, s.Client, s.Obj, s.mutateFn())
+	} else {
+		result.Operation, err = CreateIfNotExist(ctx, s.Client, s.Obj, s.mutateFn())
+	}
+
+	// check deep diff
+	diff := deep.Equal(redact(s.previousObject), redact(s.Obj))
+
+	// don't pass to user error for owner deletion, just don't create the object
+	// nolint: gocritic
+	if errors.Is(err, ErrOwnerDeleted) {
+		log.Info(string(result.Operation), "key", key, "kind", s.objectType(s.Obj), "error", err)
+		err = nil
+	} else if errors.Is(err, ErrIgnore) {
+		log.V(1).Info("syncer skipped", "key", key, "kind", s.objectType(s.Obj), "error", err)
+		err = nil
+	} else if err != nil {
+		result.SetEventData(eventWarning, basicEventReason(s.Name, err),
+			fmt.Sprintf("%s %s failed syncing: %s", s.objectType(s.Obj), key, err))
+		log.Error(err, string(result.Operation), "key", key, "kind", s.objectType(s.Obj), "diff", diff)
+	} else {
+		result.SetEventData(eventNormal, basicEventReason(s.Name, err),
+			fmt.Sprintf("%s %s %s successfully", s.objectType(s.Obj), key, result.Operation))
+		log.V(1).Info(string(result.Operation), "key", key, "kind", s.objectType(s.Obj), "diff", diff)
+	}
+
+	return result, err
+}
+
+func CreateIfNotExist(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	var err error
+	if err = c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return controllerutil.OperationResultNone, err
+		}
+
+		if err = f(); err != nil {
+			return controllerutil.OperationResultNone, err
+		}
+
+		if err = c.Create(ctx, obj); err != nil {
+			return controllerutil.OperationResultNone, err
+		} else {
+			return controllerutil.OperationResultCreated, nil
+		}
+	}
+	return controllerutil.OperationResultNone, nil
+}
+
+// objectType returns the type of a runtime.Object.
+func (s *ObjectSyncer) objectType(obj runtime.Object) string {
+	if obj != nil {
+		gvk, err := apiutil.GVKForObject(obj, s.Client.Scheme())
+		if err != nil {
+			return fmt.Sprintf("%T", obj)
+		}
+
+		return gvk.String()
+	}
+
+	return "nil"
+}
+
+// Given an ObjectSyncer, returns a controllerutil.MutateFn which also sets the
+// owner reference if the subject has one.
+func (s *ObjectSyncer) mutateFn() controllerutil.MutateFn {
+	return func() error {
+		s.previousObject = s.Obj.DeepCopyObject()
+
+		err := s.SyncFn()
+		if err != nil {
+			return err
+		}
+
+		if s.Owner == nil {
+			return nil
+		}
+
+		// set owner reference only if owner resource is not being deleted, otherwise the owner
+		// reference will be reset in case of deleting with cascade=false.
+		if s.Owner.GetDeletionTimestamp().IsZero() {
+			if err := controllerutil.SetControllerReference(s.Owner, s.Obj, s.Client.Scheme()); err != nil {
+				return err
+			}
+		} else if ctime := s.Obj.GetCreationTimestamp(); ctime.IsZero() {
+			// the owner is deleted, don't recreate the resource if does not exist, because gc
+			// will not delete it again because has no owner reference set
+			return ErrOwnerDeleted
+		}
+
+		return nil
+	}
+}
+
+func basicEventReason(objKindName string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("%sSyncFailed", strcase.ToCamel(objKindName))
+	}
+
+	return fmt.Sprintf("%sSyncSuccessfull", strcase.ToCamel(objKindName))
+}
+
+// Redacts sensitive data from runtime.Object making them suitable for logging.
+func redact(obj runtime.Object) runtime.Object {
+	switch exposed := obj.(type) {
+	case *corev1.Secret:
+		redacted := exposed.DeepCopy()
+		redacted.Data = nil
+		redacted.StringData = nil
+		exposed.ObjectMeta.DeepCopyInto(&redacted.ObjectMeta)
+
+		return redacted
+	case *corev1.ConfigMap:
+		redacted := exposed.DeepCopy()
+		redacted.Data = nil
+
+		return redacted
+	}
+
+	return obj
+}
+
+// Sync mutates the subject of the syncer interface using controller-runtime
+// CreateOrUpdate method, when obj is not nil. It takes care of setting owner
+// references and recording kubernetes events where appropriate.
+func Sync(ctx context.Context, syncer Syncer, recorder record.EventRecorder) error {
+	result, err := syncer.Sync(ctx)
+	owner := syncer.ObjectOwner()
+
+	if recorder != nil && owner != nil && result.EventType != "" && result.EventReason != "" && result.EventMessage != "" {
+		if err != nil || result.Operation != controllerutil.OperationResultNone {
+			recorder.Eventf(owner, result.EventType, result.EventReason, result.EventMessage)
+		}
+	}
+
+	return err
+}

--- a/mysqlcluster/syncer/statefulset.go
+++ b/mysqlcluster/syncer/statefulset.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/iancoleman/strcase"
 	"github.com/imdario/mergo"
 	"github.com/presslabs/controller-util/pkg/mergo/transformers"
 	"github.com/presslabs/controller-util/pkg/syncer"
@@ -556,14 +555,6 @@ func (s *StatefulSetSyncer) applyNWait(ctx context.Context, pod *corev1.Pod) err
 		}
 		return false, nil
 	})
-}
-
-func basicEventReason(objKindName string, err error) string {
-	if err != nil {
-		return fmt.Sprintf("%sSyncFailed", strcase.ToCamel(objKindName))
-	}
-
-	return fmt.Sprintf("%sSyncSuccessfull", strcase.ToCamel(objKindName))
 }
 
 // check the backup is exist and running

--- a/sidecar/init.go
+++ b/sidecar/init.go
@@ -219,20 +219,6 @@ func runInitCommand(cfg *Config) error {
 		}
 	}
 
-	// // build leader-start.sh.
-	// bashLeaderStart := cfg.buildLeaderStart()
-	// leaderStartPath := path.Join(scriptsPath, "leader-start.sh")
-	// if err = ioutil.WriteFile(leaderStartPath, bashLeaderStart, os.FileMode(0755)); err != nil {
-	// 	return fmt.Errorf("failed to write leader-start.sh: %s", err)
-	// }
-
-	// // build leader-stop.sh.
-	// bashLeaderStop := cfg.buildLeaderStop()
-	// leaderStopPath := path.Join(scriptsPath, "leader-stop.sh")
-	// if err = ioutil.WriteFile(leaderStopPath, bashLeaderStop, os.FileMode(0755)); err != nil {
-	// 	return fmt.Errorf("failed to write leader-stop.sh: %s", err)
-	// }
-
 	// for install tokudb.
 	if cfg.InitTokuDB {
 		arg := fmt.Sprintf("echo never > %s/enabled", sysPath)


### PR DESCRIPTION
### What type of PR is this?

/enhancement

### Which issue(s) this PR fixes?

ref #580

### What this PR does?

Summary:

1. add an option for the objectSyncer: forceSync; if false, objectSyncer will not force synchronous resources, it will only create resources without existence.
2. support MySQL configuration template
3. generate MySQL config template by default
4. support customized initsql


```
❯ kubectl get cm sample-mysql -oyaml
apiVersion: v1
data:
  init.sql: CREATE DATABASE IF NOT EXISTS testinit;
...

bash-4.4$ cat /etc/mysql/conf.d/init.sql 
SET @@SESSION.SQL_LOG_BIN=0;
CREATE DATABASE IF NOT EXISTS radondb;
...
FLUSH PRIVILEGES;

CREATE DATABASE IF NOT EXISTS testinit;


mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| radondb            |
| sys                |
| testinit           |
+--------------------+
6 rows in set (0.03 sec)
```

### Special notes for your reviewer?
