### PR TITLE
controllers: fix the bug cronjob exits when cluster is gone #661

### DIFF
--- a/controllers/backupcron_controller.go
+++ b/controllers/backupcron_controller.go
@@ -78,6 +78,9 @@ func (r *BackupCronReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			log.Info("instance not found, maybe removed")
+			if err := r.Cron.Remove(instance.Name); err == nil {
+				log.V(1).Info("remove cronjob from cluster", "name", instance.Name)
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -87,7 +90,11 @@ func (r *BackupCronReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 	// if spec.backupScheduler is not set then don't do anything
-	if len(instance.Spec.BackupSchedule) == 0 {
+	if len(instance.Spec.BackupSchedule) == 0 || *instance.Spec.Replicas == 0 {
+		if err := r.Cron.Remove(instance.Name); err == nil {
+			log.V(1).Info("remove cronjob from cluster", "name", instance.Name)
+		}
+
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed #xxx
2. *: what's changed #xxx

-->

### What type of PR is this?

<!--
Add one of the following types:

/documentation
/cleanup
/enhancement
-->
/bug
### Which issue(s) this PR fixes?

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #661

### What this PR does?

Summary:
1. when cluster is deleted, remove cronjob
2. when replica is zeror , remove cronjob
3. when backupschedule is set to empty, remove cronjob.
### Special notes for your reviewer?
