### PR TITLE
container: support image namespace override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Image URL to use all building/pushing image targets
+REGISTRY ?= quay.io
 IMGPREFIX ?=radondb/
 IMG ?= $(IMGPREFIX)mysql-operator:latest
 SIDECAR57_IMG ?= $(IMGPREFIX)mysql57-sidecar:latest

--- a/backup/syncer/job.go
+++ b/backup/syncer/job.go
@@ -41,7 +41,7 @@ type jobSyncer struct {
 func (s *jobSyncer) ObjectOwner() runtime.Object { return s.backup.Unwrap() }
 
 // NewJobSyncer returns a syncer for backup jobs
-func NewJobSyncer(c client.Client, s *runtime.Scheme, backup *backup.Backup) syncer.Interface {
+func NewJobSyncer(c client.Client, backup *backup.Backup) syncer.Interface {
 	obj := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backup.GetNameForJob(),
@@ -132,7 +132,7 @@ func (s *jobSyncer) ensurePodSpec(in corev1.PodSpec) corev1.PodSpec {
 	in.RestartPolicy = corev1.RestartPolicyNever
 	sctName := fmt.Sprintf("%s-secret", s.backup.Spec.ClusterName)
 	in.Containers[0].Name = utils.ContainerBackupName
-	in.Containers[0].Image = fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), s.backup.Spec.Image)
+	in.Containers[0].Image = mysqlcluster.GetImage(s.backup.Spec.Image)
 	in.ServiceAccountName = s.backup.Spec.ClusterName
 	if len(s.backup.Spec.NFSServerAddress) != 0 {
 		// add volumn about pvc

--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -25,3 +25,4 @@ appVersion: "v2.2.1"
 dependencies:
   - name: "mysqlcluster"
     version: "v2.2.1"
+    

--- a/charts/mysql-operator/Chart.yaml
+++ b/charts/mysql-operator/Chart.yaml
@@ -22,3 +22,6 @@ version: v2.2.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v2.2.1"
+dependencies:
+  - name: "mysqlcluster"
+    version: "v2.2.1"

--- a/charts/mysql-operator/templates/deployment.yaml
+++ b/charts/mysql-operator/templates/deployment.yaml
@@ -34,11 +34,22 @@ spec:
       containers:
       {{- if .Values.rbacProxy.create }}
       - name: kube-rbac-proxy
-      {{- if not .Values.imagePrefix }}
-        image: "{{ .Values.rbacProxy.image }}"
+      {{- $imagerepo:=(split "/" .Values.rbacProxy.image)._0 }}
+      {{- $imagetag:= (split "/" .Values.rbacProxy.image)._1 }}
+      {{- if .Values.imageNamespaceOverride}}
+      {{- if .Values.imagePrefix}}
+        image: {{ printf "%s/%s/%s" .Values.imagePrefix .Values.imageNamespaceOverride $imagetag|quote }}
+      {{- else  }}
+        image: {{ printf "%s/%s" .Values.imageNamespaceOverride $imagetag|quote }}
+      {{- end}}
       {{- else }}
-        image: "{{ .Values.imagePrefix }}/{{ .Values.rbacProxy.image }}"
+      {{- if .Values.imagePrefix}}
+        image: {{ printf "%s/%s/%s" .Values.imagePrefix $imagerepo $imagetag|quote }}
+      {{- else }}
+        image: {{ .Values.rbacProxy.image|quote }}
       {{- end }}
+      {{- end }}
+        imagePullPolicy: {{ .Values.rbacProxy.imagePullPolicy }}
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -70,13 +81,25 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
-      {{- if not .Values.imagePrefix }}
-        image: "{{ .Values.manager.image }}:{{ .Values.manager.tag }}"
-      {{- else }}
-        image: "{{ .Values.imagePrefix }}/{{ .Values.manager.image }}:{{ .Values.manager.tag }}"
-      {{- end }}
+        {{- $imagerepo:=(split "/" .Values.manager.image)._0 }}
+        {{- $imagetag:= printf "%s:%s" (split "/" .Values.manager.image)._1 .Values.manager.tag }}
+        {{- if .Values.imageNamespaceOverride}}
+        {{- if .Values.imagePrefix}}
+        image: {{ printf "%s/%s/%s" .Values.imagePrefix .Values.imageNamespaceOverride $imagetag|quote }}
+        {{- else  }}
+        image: {{ printf "%s/%s" .Values.imageNamespaceOverride $imagetag|quote }}
+        {{- end}}
+        {{- else }}
+        {{- if .Values.imagePrefix}}
+        image: {{ printf "%s/%s/%s" .Values.imagePrefix $imagerepo $imagetag|quote }}
+        {{- else }}
+        image: {{ printf "%s/%s" $imagerepo $imagetag|quote }}
+        {{- end }}
+        {{- end }}
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
         env:
+        - name: IMAGE_NAMESPACE_OVERRIDE
+          value: {{ .Values.imageNamespaceOverride | quote }}
         - name: IMAGE_PREFIX
           value: {{ .Values.imagePrefix }}
         - name: ENABLE_WEBHOOKS

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -16,6 +16,7 @@ imagePullPolicy: IfNotPresent
 nameOverride: ""
 fullnameOverride: ""
 imagePrefix: ""
+imageNamespaceOverride: ""
 
 ## node.kubernetes.io/not-ready:NoExecute
 ## node.kubernetes.io/unreachable:NoExecute

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -85,7 +85,7 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if len(backup.ObjectMeta.Labels["cluster"]) == 0 {
 		backup.ObjectMeta.Labels = labels.Set{"cluster": backup.Spec.ClusterName}
 	}
-	jobSyncer := backupSyncer.NewJobSyncer(r.Client, r.Scheme, backup)
+	jobSyncer := backupSyncer.NewJobSyncer(r.Client, backup)
 	if err := syncer.Sync(ctx, jobSyncer, r.Recorder); err != nil {
 		backup.UpdateStatusCondition(apiv1alpha1.BackupFailed, corev1.ConditionTrue, "CreateFailure", err.Error())
 		backup.Status.Completed = true

--- a/controllers/status_controller.go
+++ b/controllers/status_controller.go
@@ -112,7 +112,7 @@ func (r *StatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	bld := ctrl.NewControllerManagedBy(mgr).
 		For(&apiv1alpha1.MysqlCluster{}).
 		Watches(&source.Kind{Type: &apiv1alpha1.MysqlCluster{}}, &handler.Funcs{
-			CreateFunc: func(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+			CreateFunc: func(evt event.CreateEvent, _ workqueue.RateLimitingInterface) {
 				if evt.Object == nil {
 					log.Error(nil, "CreateEvent received with no metadata", "CreateEvent", evt)
 					return
@@ -121,7 +121,7 @@ func (r *StatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				log.V(1).Info("register cluster in clusters list", "obj", evt.Object)
 				clusters.Store(getKey(evt.Object), event.GenericEvent(evt))
 			},
-			DeleteFunc: func(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			DeleteFunc: func(evt event.DeleteEvent, _ workqueue.RateLimitingInterface) {
 				if evt.Object == nil {
 					log.Error(nil, "DeleteEvent received with no metadata", "DeleteEvent", evt)
 					return

--- a/mysqlcluster/container/auditlog_test.go
+++ b/mysqlcluster/container/auditlog_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,7 +56,8 @@ func TestGetAuditlogName(t *testing.T) {
 }
 
 func TestGetAuditlogImage(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "busybox"), auditLogCase.Image)
+	// assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "busybox"), auditLogCase.Image)
+	assert.Equal(t, mysqlcluster.GetImage("busybox"), auditLogCase.Image)
 }
 
 func TestGetAuditlogCommand(t *testing.T) {

--- a/mysqlcluster/container/container.go
+++ b/mysqlcluster/container/container.go
@@ -17,8 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/radondb/radondb-mysql-kubernetes/mysqlcluster"
@@ -86,7 +84,7 @@ func EnsureContainer(name string, c *mysqlcluster.MysqlCluster) corev1.Container
 
 	return corev1.Container{
 		Name:            ctr.getName(),
-		Image:           fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), ctr.getImage()),
+		Image:           mysqlcluster.GetImage(ctr.getImage()),
 		ImagePullPolicy: c.Spec.PodPolicy.ImagePullPolicy,
 		Command:         ctr.getCommand(),
 		Env:             ctr.getEnvVars(),

--- a/mysqlcluster/container/init_mysql_test.go
+++ b/mysqlcluster/container/init_mysql_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,7 +109,7 @@ func TestGetInitMysqlName(t *testing.T) {
 }
 
 func TestGetInitMysqlImage(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "percona/percona-server:5.7.34"), initMysqlCase.Image)
+	assert.Equal(t, mysqlcluster.GetImage("percona/percona-server:5.7.34"), initMysqlCase.Image)
 }
 
 func TestGetInitMysqlCommand(t *testing.T) {

--- a/mysqlcluster/container/init_sidecar_test.go
+++ b/mysqlcluster/container/init_sidecar_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -312,7 +311,8 @@ func TestGetInitSidecarName(t *testing.T) {
 }
 
 func TestGetInitSidecarImage(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "sidecar image"), initSidecarCase.Image)
+	// assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "sidecar image"), initSidecarCase.Image)
+	assert.Equal(t, mysqlcluster.GetImage("sidecar image"), initSidecarCase.Image)
 }
 
 func TestGetInitSidecarCommand(t *testing.T) {

--- a/mysqlcluster/container/metrics_test.go
+++ b/mysqlcluster/container/metrics_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,7 +56,7 @@ func TestGetMetricsName(t *testing.T) {
 }
 
 func TestGetMetricsImage(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "metrics-image"), metricsCase.Image)
+	assert.Equal(t, mysqlcluster.GetImage("metrics-image"), metricsCase.Image)
 }
 
 func TestGetMetricsCommand(t *testing.T) {

--- a/mysqlcluster/container/slowlog_test.go
+++ b/mysqlcluster/container/slowlog_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,7 +49,7 @@ func TestGetSlowlogName(t *testing.T) {
 }
 
 func TestGetSlowlogImage(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "sidecar image"), slowlogCase.Image)
+	assert.Equal(t, mysqlcluster.GetImage("sidecar image"), slowlogCase.Image)
 }
 
 func TestGetSlowlogCommand(t *testing.T) {

--- a/mysqlcluster/container/xenon_test.go
+++ b/mysqlcluster/container/xenon_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package container
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,7 +59,8 @@ func TestGetXenonName(t *testing.T) {
 }
 
 func TestGetXenonImage(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "xenon image"), xenonCase.Image)
+	// assert.Equal(t, fmt.Sprintf("%s%s", mysqlcluster.GetPrefixFromEnv(), "xenon image"), xenonCase.Image)
+	assert.Equal(t, mysqlcluster.GetImage("xenon image"), xenonCase.Image)
 }
 
 func TestGetXenonCommand(t *testing.T) {

--- a/mysqlcluster/mysqlcluster.go
+++ b/mysqlcluster/mysqlcluster.go
@@ -478,3 +478,15 @@ func GetPrefixFromEnv() string {
 	}
 	return prefix + "/"
 }
+
+// GetImage returns the image name with the prefix and override.
+func GetImage(name string) string {
+	prefix := GetPrefixFromEnv()
+	override := os.Getenv("IMAGE_NAMESPACE_OVERRIDE")
+	imagearray := strings.Split(name, "/")
+	image_namespace := strings.Join(imagearray[0:len(imagearray)-1], "/")
+	if len(override) > 0 {
+		image_namespace = override
+	}
+	return prefix + image_namespace + "/" + imagearray[len(imagearray)-1]
+}

--- a/mysqlcluster/mysqlcluster_test.go
+++ b/mysqlcluster/mysqlcluster_test.go
@@ -709,3 +709,47 @@ func TestGetPrefixFromEnv(t *testing.T) {
 		assert.Equal(t, want, result)
 	}
 }
+
+func TestGetImage(t *testing.T) {
+	{
+		t.Setenv("IMAGE_PREFIX", "docker.io")
+		t.Setenv("IMAGE_NAMESPACE_OVERRIDE", "mockrepo")
+		testCase := "radondb/mysql-operator:latest"
+		want := "docker.io/mockrepo/mysql-operator:latest"
+		result := GetImage(testCase)
+		assert.Equal(t, want, result)
+	}
+	{
+		t.Setenv("IMAGE_PREFIX", "")
+		t.Setenv("IMAGE_NAMESPACE_OVERRIDE", "mockrepo")
+		testCase := "radondb/mysql-operator:latest"
+		want := "mockrepo/mysql-operator:latest"
+		result := GetImage(testCase)
+		assert.Equal(t, want, result)
+	}
+	{
+		t.Setenv("IMAGE_PREFIX", "docker.io")
+		t.Setenv("IMAGE_NAMESPACE_OVERRIDE", "")
+		testCase := "radondb/mysql-operator:latest"
+		want := "docker.io/radondb/mysql-operator:latest"
+		result := GetImage(testCase)
+		assert.Equal(t, want, result)
+	}
+	{
+		t.Setenv("IMAGE_PREFIX", "")
+		t.Setenv("IMAGE_NAMESPACE_OVERRIDE", "")
+		testCase := "radondb/mysql-operator:latest"
+		want := "radondb/mysql-operator:latest"
+		result := GetImage(testCase)
+		assert.Equal(t, want, result)
+	}
+	{
+		// No image namespace
+		t.Setenv("IMAGE_PREFIX", "")
+		t.Setenv("IMAGE_NAMESPACE_OVERRIDE", "mockrepo")
+		testCase := "mysql-operator:latest"
+		want := "mockrepo/mysql-operator:latest"
+		result := GetImage(testCase)
+		assert.Equal(t, want, result)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed #xxx
2. *: what's changed #xxx
container: support image namespace override
-->

### What type of PR is this?

<!--
Add one of the following types:
/bug
/documentation
/cleanup
/enhancement
-->
/enhancement
### Which issue(s) this PR fixes?

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #718 

### What this PR does?

Summary:

### Special notes for your reviewer?
```shell
helm get values  mysql-operator -a|grep  ^image
imageNamespaceOverride: qq
imagePrefix: z.com
imagePullPolicy: IfNotPresent

kubectl get deployments.apps mysql-operator -o yaml|grep -E 'IMAGE_NAMESPACE_OVERRIDE|IMAGE_PREFIX|image'
        image: z.com/qq/kube-rbac-proxy:v0.8.0
        imagePullPolicy: IfNotPresent
        - name: IMAGE_NAMESPACE_OVERRIDE
        - name: IMAGE_PREFIX
        image: z.com/qq/mysql-operator:latest
        imagePullPolicy: IfNotPresent

 kubectl describe  po sample-mysql-2|grep image
  Normal  Pulled     14m   kubelet            Container image "z.com/qq/mysql57-sidecar" already present on machine
  Normal  Pulled     14m   kubelet            Container image "z.com/qq/percona-server:5.7.34" already present on machine
  Normal  Pulled     14m   kubelet            Container image "z.com/qq/percona-server:5.7.34" already present on machine
  Normal  Pulled     14m   kubelet            Container image "z.com/qq/xenon" already present on machine
  Normal  Pulled     14m   kubelet            Container image "z.com/qq/mysql57-sidecar" already present on machine
  Normal  Pulled     14m   kubelet            Container image "z.com/qq/mysqld-exporter" already present on machine
```